### PR TITLE
walkr: properly handle early lookup failures at consecutive walks

### DIFF
--- a/src/walkr.js
+++ b/src/walkr.js
@@ -7,7 +7,7 @@ function walk(object, ...keys) {
         const result = walk(obj, key);
         if (result != null) return result;
       }
-    } else if (typeof base === 'object') {
+    } else if (typeof base === 'object' && base !== null) {
       if (key in base && base[key] != null) return base[key];
       for (const value of Object.values(base)) {
         const result = walk(value, key);


### PR DESCRIPTION
When walking an object tree, with multiple lookup keys, ignore the rest when one lookup fails.

### Example

``` js
walkr({a: {b: {c: 10}}}, 'a', 'd', 'b');
```

Naturally, this should lookup `a` in the source object, `d` in the result from the lookup of `a` and thereafter `b` in the result from the lookup of `d`. But the `d` lookup fails and should promptly break lookups and return.

Currently, `b` is being queried from a `null` object returned from the failed `d` lookup. That's just wrong.

Fixes #17.