### PR TITLE
npm: workaround dependency master, fix security vuln

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@yujinakayama/apple-music": "^0.4.0",
+    "@yujinakayama/apple-music": "github:yujinakayama/apple-music-node#dependabot/npm_and_yarn/axios-0.21.1",
     "async": "^3.2.0",
     "bluebird": "^3.7.2",
     "commander": "^6.2.1",


### PR DESCRIPTION
NPM dependency [`@yujinakayama/apple-music-node`](https://github.com/yujinakayama/apple-music-node) [`v0.4.0`](https://www.npmjs.com/package/@yujinakayama/apple-music/v/0.4.0) @ [efea39c](https://github.com/yujinakayama/apple-music-node/commit/efea39c44db8ccbe45068f6cd2bfeacc4137588c), hasn't addressed critical security vulnerability in its dependency `axios`.

Until this happens, we'd switch to autogenerated dependabot branch that does fix this https://github.com/yujinakayama/apple-music-node/pull/4.