### PR TITLE
npm: workaround request deprecation message with personal fork

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "tough-cookie": "^4.0.0",
     "xbytes": "^1.6.2",
     "xprogress": "^0.17.3",
-    "youtube-dl": "^3.0.2",
+    "youtube-dl": "github:miraclx/node-youtube-dl",
     "yt-search": "^2.5.1"
   },
   "devDependencies": {}


### PR DESCRIPTION
NPM dependency [`youtube-dl`](https://github.com/przemyslawpluta/node-youtube-dl) [`v3.1.0`](https://www.npmjs.com/package/youtube-dl/v/3.1.0) @ [1b4e5a6](https://github.com/przemyslawpluta/node-youtube-dl/commit/1b4e5a65447fcdbe7c7030925359cb045b5199a4), hasn't addressed deprecation and potential migration from `request` https://github.com/request/request/issues/3142.

As a workaround, we incorporate the unmerged PR that does addresses this https://github.com/przemyslawpluta/node-youtube-dl/pull/299 with [BarryCarlyon/node-youtube-dl](https://github.com/BarryCarlyon/node-youtube-dl/tree/replacerequest) @ [`replacerequest`](https://github.com/BarryCarlyon/node-youtube-dl/tree/replacerequest) and the fairly active HEAD of the origin repo into a fork of both for synchronizing commits [miraclx/node-youtube-dl](https://github.com/miraclx/node-youtube-dl)