### PR TITLE
YouTubeMusic: include artists(s) in stripped filter

### DIFF
--- a/src/services/youtube.js
+++ b/src/services/youtube.js
@@ -284,6 +284,8 @@ class YouTubeMusic {
 
     const results = await this.#search({query: artists.concat(track).join(' ')});
     const strippedTitle = StripChar.RSspecChar(track).toLowerCase();
+    const strippedArtists = artists.map(artist => StripChar.RSspecChar(artist).toLowerCase());
+    const strippedMeta = [strippedTitle, ...strippedArtists].join(' ');
     const validSections = [
       ...((results.top || {}).contents || []), // top recommended songs
       ...((results.songs || {}).contents || []), // song section
@@ -293,11 +295,12 @@ class YouTubeMusic {
         item &&
         'title' in item &&
         most(
-          StripChar.RSspecChar(item.title)
-            .replace(/\s{2,}/g, ' ')
-            .toLowerCase()
-            .split(' '),
-          text => strippedTitle.includes(text),
+          [...item.title.split(' '), ...item.artists.map(artist => artist.name)].map(name =>
+            StripChar.RSspecChar(name)
+              .replace(/\s{2,}/g, ' ')
+              .toLowerCase(),
+          ),
+          text => strippedMeta.includes(text),
         ),
     );
     function calculateAccuracyFor(item) {


### PR DESCRIPTION
### Query ([link](https://music.youtube.com/search?q=BENEE+Supalonely+Gus+Dapperton)):

|  meta | value |
| ---- | ----- |
| `title` | `"Supalonely"` |
| `artist[0]` | `"BENEE"` |
| `artist[1]` | `"Gus Dapperton"` |

### Results[Songs][..3]:

| ref | title | artist[0] | artist[1] | album | explicit | link |
| --- | ----- | --------- | --------- | ----- | -------- | ---- |
| `0` | `"Supalonely (feat. Gus Dapperton)"` | `"BENEE"` | | `"STELLA & STEVE"` | `false` | [link](https://music.youtube.com/watch?v=SztvQd1eYlI&feature=share) |
| `1` | `"Supalonely (feat. Gus Dapperton)"` | `"BENEE"` | | `"STELLA & STEVE"` | `true` | [link](https://music.youtube.com/watch?v=bMQN-uJa2Ac&feature=share) |
| `2` | `"Supalonely (feat. Gus Dapperton)"` | `"BENEE"` | | `"Hey u x"` | `true` | [link](https://music.youtube.com/watch?v=o47dgV2xMcQ&feature=share) |

In the result, `artist[1]` from `Query` is inside the title.
So, invariably, the `most` algorithm fails to verify that most of the words in the result `title` is contained within the query `title`.

This addresses that by including the artists on both objects.