### PR TITLE
Update youtube-dl

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "tough-cookie": "^4.0.0",
     "xbytes": "^1.6.2",
     "xprogress": "^0.17.3",
-    "youtube-dl": "github:miraclx/node-youtube-dl",
+    "youtube-dl": "^3.0.2",
     "yt-search": "^2.5.1"
   },
   "devDependencies": {}

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "tough-cookie": "^4.0.0",
     "xbytes": "^1.6.2",
     "xprogress": "^0.17.3",
-    "youtube-dl": "^3.0.2",
+    "youtube-dl": "^3.4.0",
     "yt-search": "^2.5.1"
   },
   "devDependencies": {}


### PR DESCRIPTION
Fixes #40

- Reverts miraclx/freyr-js#23
- Updates [przemyslawpluta/node-youtube-dl](https://github.com/przemyslawpluta/node-youtube-dl) to v3.4.0