### PR TITLE
docker: set entrypoint to `freyr` command instead of `freyr get`

### DIFF
--- a/docker/Dockerfile.alpine
+++ b/docker/Dockerfile.alpine
@@ -42,7 +42,7 @@ WORKDIR /data
 VOLUME ["/data"]
 
 # Set entrypoint and default cmd
-ENTRYPOINT ["freyr", "-d", "/data"]
+ENTRYPOINT ["freyr"]
 CMD ["--help"]
 
 # BUILD

--- a/docker/Dockerfile.archlinux
+++ b/docker/Dockerfile.archlinux
@@ -35,7 +35,7 @@ WORKDIR /data
 VOLUME ["/data"]
 
 # Set entrypoint and default cmd
-ENTRYPOINT ["freyr", "-d", "/data"]
+ENTRYPOINT ["freyr"]
 CMD ["--help"]
 
 # BUILD


### PR DESCRIPTION
Incorrect behavior spotted in #47 

#### Example

```console
docker run -it --rm freyrcli/freyrjs urify https://open.spotify.com/playlist/37i9dQZF1DWWEcRhUVtL8n
```

should run the `urify` subcommand instead of wrongly attempting to download from a URI called `urify`