### PR TITLE
fix: workaround for feeds whose id's start with hyphen

### DIFF
--- a/src/services/youtube.js
+++ b/src/services/youtube.js
@@ -39,7 +39,8 @@ class YouTubeSearchError extends Error {
 
 function genAsyncGetFeedsFn(url) {
   return () =>
-    youtubedl(url, {
+    youtubedl(null, {
+      '--': [url],
       socketTimeout: 20,
       cacheDir: false,
       dumpSingleJson: true,


### PR DESCRIPTION
Fixes #83