### PR TITLE
fix edge case where server doesn't return a fully qualified date

### DIFF
--- a/src/services/apple_music.js
+++ b/src/services/apple_music.js
@@ -147,13 +147,15 @@ class AppleMusic {
       images: albumObject.attributes.artwork,
       label: albumObject.attributes.recordLabel,
       release_date: (date =>
-        [
-          [date.year, 4],
-          [date.month, 2],
-          [date.day, 2],
-        ]
-          .map(([val, size]) => val.toString().padStart(size, '0'))
-          .join('-'))(albumObject.attributes.releaseDate),
+        typeof date === 'string'
+          ? date
+          : [
+              [date.year, 4],
+              [date.month, 2],
+              [date.day, 2],
+            ]
+              .map(([val, size]) => val.toString().padStart(size, '0'))
+              .join('-'))(albumObject.attributes.releaseDate),
       ntracks: albumObject.attributes.trackCount,
       tracks: albumObject.relationships.tracks.data,
       getImage(width, height) {


### PR DESCRIPTION
Fixes #74

Not all `releaseDate`-s from the server response is fully qualified as in `2017-09-24`.
Some, are just years instead, like `2017`