### PR TITLE
feat: support `single` spec in `type` filter

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -300,9 +300,9 @@ const [RULE_DEFAULTS, RULE_HANDLERS] = [
       return minimatch(object.name, spec, {nocase: !props.filterCase});
     },
     type(spec, object) {
-      if (spec && !['album', 'compilation'].includes(spec)) throw new Error(`Invalid rule specification: \`${spec}\``);
+      if (spec && !['album', 'single', 'compilation'].includes(spec)) throw new Error(`Invalid rule specification: \`${spec}\``);
       if (!('compilation' in object)) return;
-      return spec === 'compilation' ? object.compilation : !object.compilation;
+      return spec === object.album_type;
     },
     artist(spec, object, props) {
       if (!('artists' in object)) return;

--- a/src/services/apple_music.js
+++ b/src/services/apple_music.js
@@ -112,6 +112,7 @@ class AppleMusic {
       artists: [trackInfo.attributes.artistName],
       album: albumInfo.name,
       album_uri: `apple_music:album:${albumInfo.id || this.parseURI(trackInfo.attributes.url).refID}`,
+      album_type: albumInfo.type,
       images: trackInfo.attributes.artwork,
       duration: trackInfo.attributes.durationInMillis,
       album_artist: albumInfo.artists[0],

--- a/src/services/deezer.js
+++ b/src/services/deezer.js
@@ -198,6 +198,7 @@ class Deezer {
       artists: [trackInfo.artist.name],
       album: albumInfo.name,
       album_uri: `deezer:album:${albumInfo.id}`,
+      album_type: albumInfo.type,
       images: albumInfo.images,
       duration: trackInfo.duration * 1000,
       album_artist: albumInfo.artists[0],
@@ -211,7 +212,7 @@ class Deezer {
       label: albumInfo.label,
       copyrights: albumInfo.copyrights,
       composers: trackInfo.contributors.map(composer => composer.name).join(', '),
-      compilation: albumInfo.record_type === 'compile',
+      compilation: albumInfo.type === 'compilation',
       getImage: albumInfo.getImage,
     };
   }

--- a/src/services/spotify.js
+++ b/src/services/spotify.js
@@ -143,6 +143,7 @@ class Spotify {
           artists: trackInfo.artists.map(artist => artist.name),
           album: albumInfo.name,
           album_uri: albumInfo.uri,
+          album_type: albumInfo.type,
           images: albumInfo.images,
           duration: trackInfo.duration_ms,
           album_artist: albumInfo.artists[0],


### PR DESCRIPTION
Supports: `freyr spotify:track:.. --filter type=single`