### PR TITLE
fix: force exit if hung

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -1335,6 +1335,7 @@ async function init(queries, options) {
     stackLogger.log(` [\u2022] Output bitrate: ${options.bitrate}`);
     stackLogger.log('===========================');
   }
+  setTimeout(process.exit, 1000);
 }
 
 const program = commander


### PR DESCRIPTION
Sometimes, `freyr` gets stuck after displaying stats. There seems to be some async tasks still processing in the background. We need to investigate this. In the meantime, this patch forces the process to exit after waiting 1 second, assuming clean exit.