### PR TITLE
chore(renovate): skip updating docker action images, got, filenamify

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,0 @@
-{
-  "labels": ["dependencies"],
-  "extends": [
-    "config:base"
-  ]
-}

--- a/renovate.json5
+++ b/renovate.json5
@@ -1,0 +1,36 @@
+{
+  "labels": [
+    "dependencies"
+  ],
+  "extends": [
+    "config:base"
+  ],
+  "schedule": "every weekend",
+  "packageRules": [
+    {
+      "enabled": false,
+      "matchFiles": [
+        ".github/workflows/publish.yml"
+      ],
+      "matchPackageNames": [
+        "docker/login-action",
+        "docker/metadata-action",
+        "docker/build-push-action"
+      ]
+    },
+    {
+      // got >=v12 is an ESM package
+      "matchPackageNames": [
+        "got"
+      ],
+      "allowedVersions": "<12"
+    },
+    {
+      // filenamify >=v5 is an ESM package
+      "matchPackageNames": [
+        "filenamify"
+      ],
+      "allowedVersions": "<5"
+    }
+  ]
+}


### PR DESCRIPTION
Skip updating the following:

- GitHub Actions
  - `docker/login-action` (https://github.com/miraclx/freyr-js/pull/133)
  - `docker/metadata-action` (https://github.com/miraclx/freyr-js/pull/134)
  - `docker/build-push-action` (https://github.com/miraclx/freyr-js/pull/132)

- NPM
  - `got` (https://github.com/miraclx/freyr-js/pull/116)
  - `filenamify` (https://github.com/miraclx/freyr-js/pull/115)