### PR TITLE
feat(CI): schedule CI testing twice weekly

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,8 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
+  schedule:
+    - cron: '0 0 * * WED,SAT' # 00:00 on Wednesdays and Saturdays, weekly.
 
 jobs:
   spotify:


### PR DESCRIPTION
Run CI tests on Wednesday and Saturdays, weekly. Helps make sure we catch any issues before users report them.