### PR TITLE
chore: version to 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0] - 2021-02-21
+
 - All dependencies updated.
 - Support `"single"` specification in `"type"` filter. <https://github.com/miraclx/freyr-js/pull/124>
 - Address hanging problem on exit. <https://github.com/miraclx/freyr-js/pull/125>
@@ -24,5 +26,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 > Release Page: <https://github.com/miraclx/freyr-js/releases/tag/v0.5.0>
 
-[unreleased]: https://github.com/miraclx/freyr-js/compare/v0.5.0...HEAD
+[unreleased]: https://github.com/miraclx/freyr-js/compare/v0.6.0...HEAD
+[0.6.0]: https://github.com/miraclx/freyr-js/releases/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/miraclx/freyr-js/releases/tag/v0.5.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "freyr",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "freyr",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@yujinakayama/apple-music": "^0.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "freyr",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "A versatile, service-agnostic music downloader and manager",
   "main": "src/freyr.js",
   "scripts": {


### PR DESCRIPTION
Scheduled release: 21-02-2022

Notable changes:
- All dependencies updated.
- Support `"single"` specification in `"type"` filter. https://github.com/miraclx/freyr-js/pull/124
- Address hanging problem on exit. https://github.com/miraclx/freyr-js/pull/125
- Touch up final stats. https://github.com/miraclx/freyr-js/pull/126
- Fix `AND` and `OR` behavior when dealing with filters. https://github.com/miraclx/freyr-js/pull/127
- Added the `CHANGELOG.md` file to track project changes. https://github.com/miraclx/freyr-js/pull/148
- Introduced CI runtime checks. https://github.com/miraclx/freyr-js/pull/121
- Introduced CI lint checks. https://github.com/miraclx/freyr-js/pull/123 https://github.com/miraclx/freyr-js/pull/137
- Automated the CI release process. https://github.com/miraclx/freyr-js/pull/123 https://github.com/miraclx/freyr-js/pull/148
- Support either `AtomicParsley` or `atomicparsley`. https://github.com/miraclx/freyr-js/pull/140
- Documents the dependency on YouTube for sourcing audio. https://github.com/miraclx/freyr-js/pull/142
- Documentation now links to file index of an example library – https://miraclx.github.io/freyr-demo-library/.