### PR TITLE
fix(vuln): update and override deps versions to fix vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "html-entities": "^2.0.6",
         "is-online": "^9.0.0",
         "isbinaryfile": "^4.0.6",
-        "libxget": "^0.9.0",
+        "libxget": "^0.9.2",
         "lodash": "^4.17.20",
         "merge2": "^1.4.1",
         "minimatch": "^5.0.0",
@@ -741,14 +741,6 @@
       "integrity": "sha512-PnjTz5nXrUo6N/UJdwPPw9fscY5qlGpJxl0jLTldEs8hBKlV+3eSNnzullRCsMON7zy/01vxJBSbN5to8zM1gQ==",
       "dependencies": {
         "axios": "^0.21.1"
-      }
-    },
-    "node_modules/@yujinakayama/apple-music/node_modules/axios": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
-      "dependencies": {
-        "follow-redirects": "^1.14.0"
       }
     },
     "node_modules/accepts": {
@@ -3069,11 +3061,11 @@
       }
     },
     "node_modules/libxget": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/libxget/-/libxget-0.9.1.tgz",
-      "integrity": "sha512-P/87hiWPV57s8Ld3vLWkdwQFdXlHlaCipvrWfBBZrhbZM4eb5leUK+WlsvJm0kZFfr1qqTDU+Mh4/k3v9lx4UQ==",
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/libxget/-/libxget-0.9.2.tgz",
+      "integrity": "sha512-GfLsgZlRkcisQfHjOwTIMiehsp7Ok5C/Tjz1RVTACwV3CbINIVFERKyRrgg96jcFvO81jOsv0hW4epNNkAWQ+g==",
       "dependencies": {
-        "axios": "^0.21.2",
+        "axios": "^0.26.0",
         "commander": "^6.2.1",
         "content-disposition": "^0.5.3",
         "content-type": "^1.0.4",
@@ -3092,14 +3084,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/libxget/node_modules/axios": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
-      "dependencies": {
-        "follow-redirects": "^1.14.0"
       }
     },
     "node_modules/libxget/node_modules/commander": {
@@ -5395,17 +5379,7 @@
       "resolved": "https://registry.npmjs.org/@yujinakayama/apple-music/-/apple-music-0.4.1.tgz",
       "integrity": "sha512-PnjTz5nXrUo6N/UJdwPPw9fscY5qlGpJxl0jLTldEs8hBKlV+3eSNnzullRCsMON7zy/01vxJBSbN5to8zM1gQ==",
       "requires": {
-        "axios": "^0.21.1"
-      },
-      "dependencies": {
-        "axios": {
-          "version": "0.21.4",
-          "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-          "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
-          "requires": {
-            "follow-redirects": "^1.14.0"
-          }
-        }
+        "axios": "0.26.0"
       }
     },
     "accepts": {
@@ -7163,11 +7137,11 @@
       }
     },
     "libxget": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/libxget/-/libxget-0.9.1.tgz",
-      "integrity": "sha512-P/87hiWPV57s8Ld3vLWkdwQFdXlHlaCipvrWfBBZrhbZM4eb5leUK+WlsvJm0kZFfr1qqTDU+Mh4/k3v9lx4UQ==",
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/libxget/-/libxget-0.9.2.tgz",
+      "integrity": "sha512-GfLsgZlRkcisQfHjOwTIMiehsp7Ok5C/Tjz1RVTACwV3CbINIVFERKyRrgg96jcFvO81jOsv0hW4epNNkAWQ+g==",
       "requires": {
-        "axios": "^0.21.2",
+        "axios": "^0.26.0",
         "commander": "^6.2.1",
         "content-disposition": "^0.5.3",
         "content-type": "^1.0.4",
@@ -7182,14 +7156,6 @@
         "xresilient": "^0.8.2"
       },
       "dependencies": {
-        "axios": {
-          "version": "0.21.4",
-          "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-          "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
-          "requires": {
-            "follow-redirects": "^1.14.0"
-          }
-        },
         "commander": {
           "version": "6.2.1",
           "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1170,8 +1170,8 @@
       }
     },
     "node_modules/cli-color": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/cli-color/-/cli-color-2.0.1.tgz",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/cli-color/-/cli-color-2.0.0.tgz",
       "integrity": "sha512-a0VZ8LeraW0jTuCkuAGMNufareGHhyZU9z8OGsW0gXd1hZGi1SRuNRXdbGkraBBKnhyUhyebFWnRbp+dIn0f0A==",
       "dependencies": {
         "ansi-regex": "^2.1.1",
@@ -3346,7 +3346,7 @@
       "resolved": "https://registry.npmjs.org/node-fzf/-/node-fzf-0.11.0.tgz",
       "integrity": "sha512-djlXFlrGSrGCHVHOr4iPRkfPuZXac6Elv0wBtKEJ383Dd/rj+9zaCu4JDZQVSGvoDRRSfJYL4roK9SLjTxeOIg==",
       "dependencies": {
-        "cli-color": "~2.0.1",
+        "cli-color": "~2.0.0",
         "keypress": "~0.2.1",
         "minimist": "~1.2.5",
         "redstar": "0.0.2",
@@ -5725,8 +5725,8 @@
       "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A=="
     },
     "cli-color": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/cli-color/-/cli-color-2.0.1.tgz",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/cli-color/-/cli-color-2.0.0.tgz",
       "integrity": "sha512-a0VZ8LeraW0jTuCkuAGMNufareGHhyZU9z8OGsW0gXd1hZGi1SRuNRXdbGkraBBKnhyUhyebFWnRbp+dIn0f0A==",
       "requires": {
         "ansi-regex": "^2.1.1",
@@ -7354,7 +7354,7 @@
       "resolved": "https://registry.npmjs.org/node-fzf/-/node-fzf-0.11.0.tgz",
       "integrity": "sha512-djlXFlrGSrGCHVHOr4iPRkfPuZXac6Elv0wBtKEJ383Dd/rj+9zaCu4JDZQVSGvoDRRSfJYL4roK9SLjTxeOIg==",
       "requires": {
-        "cli-color": "~2.0.1",
+        "cli-color": "~2.0.0",
         "keypress": "~0.2.1",
         "minimist": "~1.2.5",
         "redstar": "0.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1178,9 +1178,9 @@
       }
     },
     "node_modules/cli-color": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/cli-color/-/cli-color-1.2.0.tgz",
-      "integrity": "sha1-OlrnT9drYmevZm5p4q+70B3vNNE=",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/cli-color/-/cli-color-2.0.1.tgz",
+      "integrity": "sha512-a0VZ8LeraW0jTuCkuAGMNufareGHhyZU9z8OGsW0gXd1hZGi1SRuNRXdbGkraBBKnhyUhyebFWnRbp+dIn0f0A==",
       "dependencies": {
         "ansi-regex": "^2.1.1",
         "d": "1",
@@ -3362,7 +3362,7 @@
       "resolved": "https://registry.npmjs.org/node-fzf/-/node-fzf-0.11.0.tgz",
       "integrity": "sha512-djlXFlrGSrGCHVHOr4iPRkfPuZXac6Elv0wBtKEJ383Dd/rj+9zaCu4JDZQVSGvoDRRSfJYL4roK9SLjTxeOIg==",
       "dependencies": {
-        "cli-color": "~1.2.0",
+        "cli-color": "~2.0.1",
         "keypress": "~0.2.1",
         "minimist": "~1.2.5",
         "redstar": "0.0.2",
@@ -5751,9 +5751,9 @@
       "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A=="
     },
     "cli-color": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/cli-color/-/cli-color-1.2.0.tgz",
-      "integrity": "sha1-OlrnT9drYmevZm5p4q+70B3vNNE=",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/cli-color/-/cli-color-2.0.1.tgz",
+      "integrity": "sha512-a0VZ8LeraW0jTuCkuAGMNufareGHhyZU9z8OGsW0gXd1hZGi1SRuNRXdbGkraBBKnhyUhyebFWnRbp+dIn0f0A==",
       "requires": {
         "ansi-regex": "^2.1.1",
         "d": "1",
@@ -7388,7 +7388,7 @@
       "resolved": "https://registry.npmjs.org/node-fzf/-/node-fzf-0.11.0.tgz",
       "integrity": "sha512-djlXFlrGSrGCHVHOr4iPRkfPuZXac6Elv0wBtKEJ383Dd/rj+9zaCu4JDZQVSGvoDRRSfJYL4roK9SLjTxeOIg==",
       "requires": {
-        "cli-color": "~1.2.0",
+        "cli-color": "~2.0.1",
         "keypress": "~0.2.1",
         "minimist": "~1.2.5",
         "redstar": "0.0.2",

--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
     "yt-search": {
       "node-fzf": {
         ".": "0.11.0",
+        "cli-color": "2.0.0",
         "string-width": "5.1.0"
       }
     }

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "html-entities": "^2.0.6",
     "is-online": "^9.0.0",
     "isbinaryfile": "^4.0.6",
-    "libxget": "^0.9.0",
+    "libxget": "^0.9.2",
     "lodash": "^4.17.20",
     "merge2": "^1.4.1",
     "minimatch": "^5.0.0",
@@ -101,6 +101,9 @@
         "cli-color": "2.0.0",
         "string-width": "5.1.0"
       }
+    },
+    "@yujinakayama/apple-music": {
+      "axios": "0.26.0"
     }
   }
 }


### PR DESCRIPTION
- `yt-search` depended on `node-fzf` which depended on a stale version of `cli-color` depending on a vulnerable version of `ansi-regex`
- `libxget` and `@yujinakayama/apple-music` both depended on the now stale `axios@0.21.4` which depended on a vulnerable version of `follow-redirects`