### PR TITLE
chore: version to 0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.7.0] - 2022-03-31
+## [0.7.0] - 2022-06-09
 
+- Updated Apple Music access key. <https://github.com/miraclx/freyr-js/pull/191>
 - Simplified the output of using the `-v, --version`. <https://github.com/miraclx/freyr-js/pull/152>
 - Dropped extra version in the header. <https://github.com/miraclx/freyr-js/pull/153>
 - Fixed issue with docker build not bundling dependencies. <https://github.com/miraclx/freyr-js/pull/165>
 - Update dependencies.
-  - `eslint`: `8.9.0` -> `8.11.0`. <https://github.com/miraclx/freyr-js/pull/154> <https://github.com/miraclx/freyr-js/pull/161>
-  - `actions/setup-node`: `v2` -> `v3`. <https://github.com/miraclx/freyr-js/pull/155>
-  - `actions/checkout`: `v2` -> `v3`. <https://github.com/miraclx/freyr-js/pull/156>
 
 ## [0.6.0] - 2022-02-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.7.0] - 2021-03-31
+## [0.7.0] - 2022-03-31
 
 - Simplified the output of using the `-v, --version`. <https://github.com/miraclx/freyr-js/pull/152>
 - Dropped extra version in the header. <https://github.com/miraclx/freyr-js/pull/153>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0] - 2021-03-31
+
 - Simplified the output of using the `-v, --version`. <https://github.com/miraclx/freyr-js/pull/152>
 - Dropped extra version in the header. <https://github.com/miraclx/freyr-js/pull/153>
 - Update dependencies.
@@ -33,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 > Release Page: <https://github.com/miraclx/freyr-js/releases/tag/v0.5.0>
 
-[unreleased]: https://github.com/miraclx/freyr-js/compare/v0.6.0...HEAD
+[unreleased]: https://github.com/miraclx/freyr-js/compare/v0.7.0...HEAD
+[0.7.0]: https://github.com/miraclx/freyr-js/releases/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/miraclx/freyr-js/releases/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/miraclx/freyr-js/releases/tag/v0.5.0

--- a/README.md
+++ b/README.md
@@ -254,9 +254,9 @@ Usage: freyr [options] [query...]
   / /_/ ___/ _ \/ / / / ___/
  / __/ /  /  __/ /_/ / /
 /_/ /_/   \___/\__, /_/
-              /____/ v0.1.0
+              /____/ v0.7.0
 
-freyr v0.1.0 - (c) Miraculous Owonubi <omiraculous@gmail.com>
+freyr - (c) Miraculous Owonubi <omiraculous@gmail.com>
 -------------------------------------------------------------
 Usage: freyr get [options] [query...]
 
@@ -349,9 +349,9 @@ Info:
   / /_/ ___/ _ \/ / / / ___/
  / __/ /  /  __/ /_/ / /
 /_/ /_/   \___/\__, /_/
-              /____/ v0.1.0
+              /____/ v0.7.0
 
-freyr v0.1.0 - (c) Miraculous Owonubi <omiraculous@gmail.com>
+freyr - (c) Miraculous Owonubi <omiraculous@gmail.com>
 -------------------------------------------------------------
 Checking directory permissions...[done]
 [spotify:track:5FNS5Vj69AhRGJWjhrAd01]
@@ -410,9 +410,9 @@ Checking directory permissions...[done]
   / /_/ ___/ _ \/ / / / ___/
  / __/ /  /  __/ /_/ / /
 /_/ /_/   \___/\__, /_/
-              /____/ v0.1.0
+              /____/ v0.7.0
 
-freyr v0.1.0 - (c) Miraculous Owonubi <omiraculous@gmail.com>
+freyr - (c) Miraculous Owonubi <omiraculous@gmail.com>
 -------------------------------------------------------------
 Checking directory permissions...[done]
 [https://music.apple.com/us/album/im-sorry-im-not-sorry-ep/1491795443]
@@ -495,9 +495,9 @@ Checking directory permissions...[done]
   / /_/ ___/ _ \/ / / / ___/
  / __/ /  /  __/ /_/ / /
 /_/ /_/   \___/\__, /_/
-              /____/ v0.1.0
+              /____/ v0.7.0
 
-freyr v0.1.0 - (c) Miraculous Owonubi <omiraculous@gmail.com>
+freyr - (c) Miraculous Owonubi <omiraculous@gmail.com>
 -------------------------------------------------------------
 Checking directory permissions...[done]
 [https://www.deezer.com/us/artist/14808825]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "freyr",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "freyr",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@yujinakayama/apple-music": "^0.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "freyr",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "A versatile, service-agnostic music downloader and manager",
   "main": "src/freyr.js",
   "scripts": {


### PR DESCRIPTION
Scheduled release: 09-06-2022

Notable changes:

- Updated Apple Music access key. <https://github.com/miraclx/freyr-js/pull/191>
- Simplified the output of using the `-v, --version`. <https://github.com/miraclx/freyr-js/pull/152>
- Dropped extra version in the header. <https://github.com/miraclx/freyr-js/pull/153>
- Fixed issue with docker build not bundling dependencies. <https://github.com/miraclx/freyr-js/pull/165>
- Update dependencies.