### PR TITLE
fix: bundle dependencies with docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,9 @@ RUN addgroup -g 1000 freyr \
 
 # Stage and install freyr
 COPY . /freyr
-RUN npm install --global --unsafe-perm /freyr \
+RUN cd /freyr \
+  && npm ci \
+  && npm link --unsafe-perm \
   && npm cache clean --force \
   && mkdir /data \
   && chown -R freyr:freyr /freyr /data

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,8 +34,8 @@ RUN addgroup -g 1000 freyr \
 
 # Stage and install freyr
 COPY . /freyr
-RUN cd /freyr \
-  && npm ci \
+WORKDIR /freyr
+RUN npm ci \
   && npm link \
   && npm cache clean --force \
   && mkdir /data \

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ RUN addgroup -g 1000 freyr \
 COPY . /freyr
 RUN cd /freyr \
   && npm ci \
-  && npm link --unsafe-perm \
+  && npm link \
   && npm cache clean --force \
   && mkdir /data \
   && chown -R freyr:freyr /freyr /data


### PR DESCRIPTION
https://github.com/miraclx/freyr-js/issues/164 highlighted an issue with the docker image. This fixes that by ensuring an intermediate installation step, bundling the dependencies in the docker image.