### PR TITLE
Failed while embedding metadata [255]

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,14 +16,28 @@ RUN apk add \
   ffmpeg \
   bash \
   which \
+  cmake \
+  gcc \
+  g++ \
+  make \
+  linux-headers \
   && ln /usr/bin/python3 /usr/bin/python \
   && find /usr/lib/python3* -type d -name __pycache__ -exec rm -r {} \+
 
 # install atomicparsley
+# clones and checkouts to latest stable tag...
+# ... then compiles and moves the binary to bins directory
 RUN mkdir /bins \
-  && wget -nv https://github.com/wez/atomicparsley/releases/download/20210715.151551.e7ad03a/AtomicParsleyAlpine.zip \
-  && unzip -j AtomicParsleyAlpine.zip AtomicParsley -d /bins \
-  && rm -v AtomicParsleyAlpine.zip
+  && git clone https://github.com/wez/atomicparsley \
+  && cd atomicparsley \
+  && git fetch --tags \
+  && latestTag=$(git describe --tags `git rev-list --tags --max-count=1`) \
+  && git checkout $latestTag \
+  && cmake . \
+  && cmake --build . --config Release \
+  && mv AtomicParsley /bins \
+  && cd .. \
+  && rm -r atomicparsley
 ENV PATH "/bins:$PATH"
 
 # Create freyr user and group

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,8 +25,6 @@ RUN apk add \
   && find /usr/lib/python3* -type d -name __pycache__ -exec rm -r {} \+
 
 # install atomicparsley
-# clones and checkouts to latest stable tag...
-# ... then compiles and moves the binary to bins directory
 RUN mkdir /bins \
   && git clone --branch 20210715.151551.e7ad03a --depth 1 https://github.com/wez/atomicparsley \
   && cmake -S atomicparsley -B atomicparsley \

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,15 +28,10 @@ RUN apk add \
 # clones and checkouts to latest stable tag...
 # ... then compiles and moves the binary to bins directory
 RUN mkdir /bins \
-  && git clone https://github.com/wez/atomicparsley \
-  && cd atomicparsley \
-  && git fetch --tags \
-  && latestTag=$(git describe --tags `git rev-list --tags --max-count=1`) \
-  && git checkout $latestTag \
-  && cmake . \
-  && cmake --build . --config Release \
-  && mv AtomicParsley /bins \
-  && cd .. \
+  && git clone --branch 20210715.151551.e7ad03a --depth 1 https://github.com/wez/atomicparsley \
+  && cmake -S atomicparsley -B atomicparsley \
+  && cmake --build atomicparsley --config Release \
+  && mv atomicparsley/AtomicParsley /bins \
   && rm -r atomicparsley
 ENV PATH "/bins:$PATH"
 


### PR DESCRIPTION
Fixes #194
__**CHANGELOG:**__
Edited the atomicparsley installation step in the Dockerfile.
Insead of downloading the precompiled binary, now clones the repo at the latest stable tag and compiles it at image build time.
This fixes the issue of AtomicParsley only working on x86 images, because it gets build for the target architecture like the image.