### PR TITLE
chore: experiment with publish docker pr images

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -278,7 +278,7 @@ jobs:
       with:
         images: freyrcli/freyrjs-pr
         tags: |
-          type=ref,event=pr,prefix=pr-
+          type=ref,event=pr,prefix=
 
     - name: Build and push Docker image
       uses: docker/build-push-action@7f9d37fa544684fb73bfe4835ed7214c255ce02b


### PR DESCRIPTION
Experiment with building docker images for every PR and pushing to a staging repo.

Every PR publishes its corresponding docker image to `freyrcli/freyrjs-git:pr-<id>` 

Example, to pull the docker image for this PR:

```console
$ docker pull freyrcli/freyrjs-git:pr-218
```