### PR TITLE
chore(CI): add badges to PR docker build comments

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -297,7 +297,6 @@ jobs:
 
           | **Last Master** | ![](https://img.shields.io/docker/image-size/freyrcli/freyrjs-git/master?color=gray&label=%20&logo=docker) |
           | - | - |
-          | **This Patch** | ![](https://img.shields.io/docker/image-size/freyrcli/freyrjs-git/${{steps.meta2.outputs.tag}}?color=gray&label=%20&logo=docker) |
 
           ---
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -295,7 +295,7 @@ jobs:
           docker pull freyrcli/freyrjs-git:${{steps.meta2.outputs.tag}}
           ```
 
-          | **Last Master** | ![](https://img.shields.io/docker/image-size/freyrcli/freyrjs-git/master?color=gray&label=%20&logo=docker) |
+          | [**Latest Master**][master-url] | [![](https://img.shields.io/docker/image-size/freyrcli/freyrjs-git/master?color=gray&label=%20&logo=docker)][master-url] |
           | - | - |
 
           ---
@@ -309,6 +309,8 @@ jobs:
 
           </details>
           </div>
+
+          [master-url]: https://hub.docker.com/r/freyrcli/freyrjs-git/tags?name=master
 
     - name: Set up QEMU
       uses: docker/setup-qemu-action@8b122486cedac8393e77aa9734c3528886e4a1a8
@@ -348,9 +350,9 @@ jobs:
           docker pull freyrcli/freyrjs-git:${{steps.meta2.outputs.tag}}
           ```
 
-          | **Last Master** | ![](https://img.shields.io/docker/image-size/freyrcli/freyrjs-git/master?color=gray&label=%20&logo=docker) |
+          | [**Latest Master**][master-url] | [![](https://img.shields.io/docker/image-size/freyrcli/freyrjs-git/master?color=gray&label=%20&logo=docker)][master-url] |
           | - | - |
-          | **This Patch** | ![](https://img.shields.io/docker/image-size/freyrcli/freyrjs-git/${{steps.meta2.outputs.tag}}?color=gray&label=%20&logo=docker) |
+          | [**This Patch**][pr-url] | [![](https://img.shields.io/docker/image-size/freyrcli/freyrjs-git/${{steps.meta2.outputs.tag}}?color=gray&label=%20&logo=docker)][pr-url] |
 
           ---
 
@@ -363,6 +365,9 @@ jobs:
 
           </details>
           </div>
+
+          [master-url]: https://hub.docker.com/r/freyrcli/freyrjs-git/tags?name=master
+          [pr-url]: https://hub.docker.com/r/freyrcli/freyrjs-git/tags?name=${{steps.meta2.outputs.tag}}
 
   linter:
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -295,6 +295,10 @@ jobs:
           docker pull freyrcli/freyrjs-git:${{steps.meta2.outputs.tag}}
           ```
 
+          | **Last Master** | ![](https://img.shields.io/docker/image-size/freyrcli/freyrjs-git/master?color=gray&label=%20&logo=docker) |
+          | - | - |
+          | **This Patch** | ![](https://img.shields.io/docker/image-size/freyrcli/freyrjs-git/${{steps.meta2.outputs.tag}}?color=gray&label=%20&logo=docker) |
+
           ---
 
           <details>
@@ -344,6 +348,10 @@ jobs:
           ```console
           docker pull freyrcli/freyrjs-git:${{steps.meta2.outputs.tag}}
           ```
+
+          | **Last Master** | ![](https://img.shields.io/docker/image-size/freyrcli/freyrjs-git/master?color=gray&label=%20&logo=docker) |
+          | - | - |
+          | **This Patch** | ![](https://img.shields.io/docker/image-size/freyrcli/freyrjs-git/${{steps.meta2.outputs.tag}}?color=gray&label=%20&logo=docker) |
 
           ---
 


### PR DESCRIPTION
Adds a size comparison between the docker image generated from the PR patch in comparison to the latest master.

### Example

Before:

> ![image](https://user-images.githubusercontent.com/16881812/177126499-c4a855e1-fc3d-4f87-a943-e7b05f95a1d2.png)

After:

> ![image](https://user-images.githubusercontent.com/16881812/177126380-afaa40bf-8d34-4a8a-9e80-cad96e5dacfb.png)