### PR TITLE
chore: docker images for master commits stay persistent

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -260,6 +260,13 @@ jobs:
     - name: Checkout Repository
       uses: actions/checkout@v3
 
+    - name: Check If Is PR
+      id: is_pr
+      run: |
+        if [[ "${{ github.event_name }}" != 'pull_request' ]]; then
+          echo "::set-output name=sha::type=sha,format=short,prefix="
+        fi
+
     - name: Extract metadata (tags, labels) for Docker
       id: meta
       uses: docker/metadata-action@e5622373a38e60fb6d795a4421e56882f2d7a681
@@ -268,6 +275,7 @@ jobs:
         tags: |
           type=ref,event=pr
           type=ref,event=branch
+          ${{ steps.is_pr.outputs.sha }}
 
     - name: Extract Tag
       id: meta2


### PR DESCRIPTION
Part 1 of #238, docker images built from every push to master should stay referentiable.

This would ensure that a commit would always have an associated docker image.