### PR TITLE
chore(CI): link python to python3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,8 @@ RUN go install github.com/tj/node-prune@1159d4c \
 FROM alpine:3.16.0 as base
 
 # hadolint ignore=DL3018
-RUN apk add --no-cache nodejs ffmpeg python3 libstdc++
+RUN apk add --no-cache nodejs ffmpeg python3 libstdc++ \
+  && ln /usr/bin/python3 /usr/bin/python
 COPY --from=installer /freyr /freyr
 RUN rm -rf /freyr/node_modules
 COPY --from=prep /freyr/node_modules /freyr/node_modules


### PR DESCRIPTION
Alpine installing `python3` isn't sufficient enough for `youtube-dl` that seeks the presence of the `python` command.

Instead of installing another `python` binary, we link it.