### PR TITLE
chore: remove __pycache__ stripping heavy binaries in our final image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,8 @@ FROM alpine:3.16.0 as base
 
 # hadolint ignore=DL3018
 RUN apk add --no-cache nodejs ffmpeg python3 libstdc++ \
-  && ln /usr/bin/python3 /usr/bin/python
+  && ln /usr/bin/python3 /usr/bin/python \
+  && find /usr/lib/python3* -type d -name __pycache__ -exec rm -r {} \+
 COPY --from=installer /freyr /freyr
 RUN rm -rf /freyr/node_modules
 COPY --from=prep /freyr/node_modules /freyr/node_modules


### PR DESCRIPTION
The `__pycache__` folder contains a bunch of precompiled binaries typically used to optimize runtime for python libraries.

But really, they don't need to come bundled with our final image. We can have them compiled just in time.