### PR TITLE
chore: remove python wheels

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,9 +27,9 @@ LABEL maintainer="Miraculous Owonubi <omiraculous@gmail.com>"
 RUN apk add --no-cache nodejs ffmpeg python3 libstdc++ \
   && ln /usr/bin/python3 /usr/bin/python \
   && find /usr/lib/python3* \
-      \( -type d -name __pycache__ \) \
+       \( -type d -name __pycache__ \) \
      -o \
-      \( -type f -name '*.whl' \) \
+       \( -type f -name '*.whl' \) \
      -exec rm -r {} \+
 COPY --from=installer /freyr /freyr
 RUN rm -rf /freyr/node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,10 +25,9 @@ FROM alpine:3.16.0 as base
 RUN apk add --no-cache nodejs ffmpeg python3 libstdc++ \
   && ln /usr/bin/python3 /usr/bin/python \
   && find /usr/lib/python3* \
-       \( -type d -name __pycache__ \) \
-     -o \
-       \( -type f -name '*.whl' \) \
-     -exec rm -r {} \+
+      \( -type d -name __pycache__ \) -o \
+      \( -type f -name '*.whl' \) \
+      -exec rm -r {} \+
 COPY --from=installer /freyr /freyr
 RUN rm -rf /freyr/node_modules
 COPY --from=prep /freyr/node_modules /freyr/node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,8 +25,7 @@ FROM alpine:3.16.0 as base
 RUN apk add --no-cache nodejs ffmpeg python3 libstdc++ \
   && ln /usr/bin/python3 /usr/bin/python \
   && find /usr/lib/python3* \
-      \( -type d -name __pycache__ \) -o \
-      \( -type f -name '*.whl' \) \
+      \( -type d -name __pycache__ -o -type f -name '*.whl' \) \
       -exec rm -r {} \+
 COPY --from=installer /freyr /freyr
 RUN rm -rf /freyr/node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,8 +21,6 @@ RUN go install github.com/tj/node-prune@1159d4c \
 
 FROM alpine:3.16.0 as base
 
-LABEL maintainer="Miraculous Owonubi <omiraculous@gmail.com>"
-
 # hadolint ignore=DL3018
 RUN apk add --no-cache nodejs ffmpeg python3 libstdc++ \
   && ln /usr/bin/python3 /usr/bin/python \

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,10 +19,16 @@ RUN go install github.com/tj/node-prune@1159d4c \
 
 FROM alpine:3.16.0 as base
 
+LABEL maintainer="Miraculous Owonubi <omiraculous@gmail.com>"
+
 # hadolint ignore=DL3018
 RUN apk add --no-cache nodejs ffmpeg python3 libstdc++ \
   && ln /usr/bin/python3 /usr/bin/python \
-  && find /usr/lib/python3* -type d -name __pycache__ -exec rm -r {} \+
+  && find /usr/lib/python3* \
+      \( -type d -name __pycache__ \) \
+     -o \
+      \( -type f -name '*.whl' \) \
+     -exec rm -r {} \+
 COPY --from=installer /freyr /freyr
 RUN rm -rf /freyr/node_modules
 COPY --from=prep /freyr/node_modules /freyr/node_modules


### PR DESCRIPTION
Remove any python wheels in the image.

Notably `/usr/lib/python*/ensurepip/_bundled/*.whl`

Contributes to making the docker image lighter: #257