### PR TITLE
chore(CI): ensure lockfiles stay up to date

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,14 +21,14 @@ jobs:
       run: |
         rm -rf node_modules
         git restore yarn.lock
-        yarn install --frozen-lockfile
+        yarn install
         git diff --no-ext-diff --quiet yarn.lock
 
     - name: Install Dependencies via NPM
       run: |
         rm -rf node_modules
         git restore package-lock.json
-        npm ci
+        npm install
         git diff --no-ext-diff --quiet package-lock.json
 
   fmt:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,11 +21,13 @@ jobs:
       run: |
         rm -rf node_modules
         yarn install --frozen-lockfile
+        git diff --no-ext-diff --quiet
 
     - name: Install Dependencies via NPM
       run: |
         rm -rf node_modules
         npm ci
+        git diff --no-ext-diff --quiet
 
   fmt:
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,14 +20,16 @@ jobs:
     - name: Install Dependencies via Yarn
       run: |
         rm -rf node_modules
+        git restore yarn.lock
         yarn install --frozen-lockfile
-        git diff --no-ext-diff --quiet
+        git diff --no-ext-diff --quiet yarn.lock
 
     - name: Install Dependencies via NPM
       run: |
         rm -rf node_modules
+        git restore package-lock.json
         npm ci
-        git diff --no-ext-diff --quiet
+        git diff --no-ext-diff --quiet package-lock.json
 
   fmt:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Add tests to ensure `npm install` / `yarn install` doesn't update lockfiles.