### PR TITLE
chore: skipping group discriminants

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,12 +41,13 @@ jobs:
       run: npx eslint --max-warnings 0 .
 
   spotify:
+    if: false
     runs-on: ubuntu-latest
-
     steps:
     - run: true
 
   spotify-track:
+    if: ${{ always() }}
     runs-on: ubuntu-latest
     needs: [ spotify ]
 
@@ -76,6 +77,7 @@ jobs:
         npm run test -- spotify.track
 
   spotify-album:
+    if: ${{ always() }}
     runs-on: ubuntu-latest
     needs: [ spotify ]
 
@@ -105,6 +107,7 @@ jobs:
         npm run test -- spotify.album
 
   spotify-artist:
+    if: ${{ always() }}
     runs-on: ubuntu-latest
     needs: [ spotify ]
 
@@ -134,6 +137,7 @@ jobs:
         npm run test -- spotify.artist
 
   spotify-playlist:
+    if: ${{ always() }}
     runs-on: ubuntu-latest
     needs: [ spotify ]
 
@@ -163,12 +167,13 @@ jobs:
         npm run test -- spotify.playlist
 
   apple-music:
+    if: false
     runs-on: ubuntu-latest
-
     steps:
     - run: true
 
   apple-music-track:
+    if: ${{ always() }}
     runs-on: ubuntu-latest
     needs: [ apple-music ]
 
@@ -198,6 +203,7 @@ jobs:
         npm run test -- apple_music.track
 
   apple-music-album:
+    if: ${{ always() }}
     runs-on: ubuntu-latest
     needs: [ apple-music ]
 
@@ -227,6 +233,7 @@ jobs:
         npm run test -- apple_music.album
 
   apple-music-artist:
+    if: ${{ always() }}
     runs-on: ubuntu-latest
     needs: [ apple-music ]
 
@@ -256,6 +263,7 @@ jobs:
         npm run test -- apple_music.artist
 
   apple-music-playlist:
+    if: ${{ always() }}
     runs-on: ubuntu-latest
     needs: [ apple-music ]
 
@@ -285,12 +293,13 @@ jobs:
         npm run test -- apple_music.playlist
 
   deezer:
+    if: false
     runs-on: ubuntu-latest
-
     steps:
     - run: true
 
   deezer-track:
+    if: ${{ always() }}
     runs-on: ubuntu-latest
     needs: [ deezer ]
 
@@ -320,6 +329,7 @@ jobs:
         npm run test -- deezer.track
 
   deezer-album:
+    if: ${{ always() }}
     runs-on: ubuntu-latest
     needs: [ deezer ]
 
@@ -349,6 +359,7 @@ jobs:
         npm run test -- deezer.album
 
   deezer-artist:
+    if: ${{ always() }}
     runs-on: ubuntu-latest
     needs: [ deezer ]
 
@@ -378,6 +389,7 @@ jobs:
         npm run test -- deezer.artist
 
   deezer-playlist:
+    if: ${{ always() }}
     runs-on: ubuntu-latest
     needs: [ deezer ]
 


### PR DESCRIPTION
https://github.com/miraclx/freyr-js/pull/266 split up the service units into groups. This means three no-op checks show up in PRs..

![Screenshot_20220713_145250](https://user-images.githubusercontent.com/16881812/178751060-9eee8cff-ca1f-4ec0-b03c-94f19ede82eb.png)

they show green even though they didn't technically test anything, this removes that, but still runs the jobs that are dependent on it.

| Before | After |
| :-: | :-: |
| ![Screenshot_20220713_145835](https://user-images.githubusercontent.com/16881812/178751692-94d47816-a29b-420f-8624-4be2cce406e9.png) | ![Screenshot_20220713_145720](https://user-images.githubusercontent.com/16881812/178751519-095635fe-4e14-4f22-a695-97bf4c17f1b3.png) |