### PR TITLE
docker: run freyr inside shell to allow proper signalling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,5 +44,5 @@ USER freyr
 WORKDIR /data
 VOLUME /data
 
-ENTRYPOINT ["freyr"]
+ENTRYPOINT ["/freyr/freyr.sh"]
 CMD ["--help"]

--- a/freyr.sh
+++ b/freyr.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+node $(dirname "$0")/cli.js $@

--- a/freyr.sh
+++ b/freyr.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-node $(dirname "$0")/cli.js $@
+node "$(dirname "$0")"/cli.js "$@"


### PR DESCRIPTION
Sometimes, when running freyr inside its docker container, it won't receive signals. But running it via a shell would appropriately send those signals to the freyr process.