### PR TITLE
chore: skip service authentication when running in CI

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -72,7 +72,9 @@ async function run_tests(stage, args) {
 
     let {uri, filter = [], expect} = stage[service][type];
 
-    let child_args = ['--no-logo', '--no-header', '--no-bar', uri, ...filter.map(f => `--filter=${f}`)];
+    let preargs = ['--no-logo', '--no-header', '--no-bar'];
+    if (is_gha) preargs.push('--no-auth');
+    let child_args = [...preargs, uri, ...filter.map(f => `--filter=${f}`)];
 
     let unmetExpectations = new Error('One or more expectations failed');
 


### PR DESCRIPTION
CI would get stuck whenever a service fails to authenticate as freyr would fallback to the authentication procedure. Which would require action from the user. Since the user can't provide any input while in CI, freyr should just fail outright.

https://github.com/miraclx/freyr-js/actions/runs/2664123334