### PR TITLE
test: print command line when executing test units

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -115,14 +115,14 @@ async function run_tests(stage, args) {
       let child, handler;
 
       if (!docker_image) {
-        child = spawn('node', [path.join(__dirname, '..', 'cli.js'), ...child_args]);
+        child = spawn('node', [path.relative(process.cwd(), path.join(__dirname, '..', 'cli.js')), ...child_args]);
       } else {
         let extra_docker_args = process.env['DOCKER_ARGS'] ? process.env['DOCKER_ARGS'].split(' ') : [];
         child = spawn('docker', [
           'run',
           ...extra_docker_args,
           '--rm',
-          '-i',
+          '--interactive',
           '--log-driver=none',
           '--name',
           child_id,
@@ -131,6 +131,8 @@ async function run_tests(stage, args) {
         ]);
         process.on('SIGINT', (handler = () => (spawn('docker', ['kill', child_id]), process.off('SIGINT', handler))));
       }
+
+      stdout.log(`\n$ ${child.spawnargs.join(' ')}\n`);
 
       let childErrors = [];
       child.on('error', err => childErrors.push(err));


### PR DESCRIPTION
Adds a line that shows the command executed for each test unit

```
> freyr@0.7.0 test
> node test/index.js

Log File: /tmp/freyr-test/b8b81f50-1957-4c05-b6e5-e06b6477355c/spotify-track-1.log
┌──> [1/3] spotify track ────────────────────────────────────┐
│ 
│ $ docker run --rm --interactive --log-driver=none --name b8b81f50-1957-4c05-b6e5-e06b6477355c freyr-dev:master --no-logo --no-header --no-bar https://open.spotify.com/track/5FNS5Vj69AhRGJWjhrAd01
│ 
│ Checking directory permissions...[done] 
```