### PR TITLE
allow authentication through a docker image

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -126,6 +126,8 @@ async function run_tests(stage, args) {
           '--log-driver=none',
           '--name',
           child_id,
+          '--network',
+          'host',
           docker_image,
           ...child_args,
         ]);


### PR DESCRIPTION
When running freyr inside a docker image, and it fails to authenticate, it requires input from the user. This allows us to bind a port inside the container with one on the host so you can open the local url in your browser to complete the authentication procedure.