### PR TITLE
eslint: ignore cli_server because of super linter

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -19,7 +19,8 @@
     "prettier"
   ],
   "ignorePatterns": [
-    "**/*.json"
+    "**/*.json",
+    "**/cli_server.js" // todo: #290, remove this when super-linter upgrades their eslint version
   ],
   "rules": {
     "prettier/prettier": [


### PR DESCRIPTION
https://github.com/miraclx/freyr-js/runs/7665631006?check_suite_focus=true

https://github.com/github/super-linter/issues/2871