### PR TITLE
use cached nodejs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,8 +20,10 @@ RUN go install github.com/tj/node-prune@1159d4c \
 
 FROM alpine:3.16.1 as base
 
+COPY --from=installer /usr/local/bin/node /usr/local/bin/node
+
 # hadolint ignore=DL3018
-RUN apk add --no-cache nodejs ffmpeg python3 libstdc++ \
+RUN apk add --no-cache ffmpeg python3 libstdc++ \
   && find /usr/lib/python3* \
       \( -type d -name __pycache__ -o -type f -name '*.whl' \) \
       -exec rm -r {} \+

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,8 @@ RUN printf '#!/usr/bin/env sh\necho "Python 3.7.0"\n' > /usr/bin/python3 && chmo
 # ^-- Workaround to bypass youtube-dl-exec's postinstall check for a supported python installation
 COPY package.json yarn.lock /freyr/
 WORKDIR /freyr
+
+# hadolint ignore=DL3018
 RUN apk add --no-cache binutils && strip /usr/local/bin/node \
   && yarn install --prod --frozen-lockfile
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,8 @@ RUN printf '#!/usr/bin/env sh\necho "Python 3.7.0"\n' > /usr/bin/python3 && chmo
 # ^-- Workaround to bypass youtube-dl-exec's postinstall check for a supported python installation
 COPY package.json yarn.lock /freyr/
 WORKDIR /freyr
-RUN yarn install --prod --frozen-lockfile
+RUN apk add --no-cache binutils && strip /usr/local/bin/node \
+  && yarn install --prod --frozen-lockfile
 
 FROM golang:1.19.0-alpine3.16 as prep
 


### PR DESCRIPTION
test difference between `apk add nodejs` and reusing the built binary from the official nodejs image.