### PR TITLE
add shell pause when run from docker desktop

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN go install github.com/tj/node-prune@1159d4c \
 FROM alpine:3.16.1 as base
 
 # hadolint ignore=DL3018
-RUN apk add --no-cache nodejs ffmpeg python3 \
+RUN apk add --no-cache ncurses nodejs ffmpeg python3 \
   && find /usr/lib/python3* \
       \( -type d -name __pycache__ -o -type f -name '*.whl' \) \
       -exec rm -r {} \+

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN go install github.com/tj/node-prune@1159d4c \
 FROM alpine:3.16.1 as base
 
 # hadolint ignore=DL3018
-RUN apk add --no-cache ncurses nodejs ffmpeg python3 \
+RUN apk add --no-cache nodejs ffmpeg python3 \
   && find /usr/lib/python3* \
       \( -type d -name __pycache__ -o -type f -name '*.whl' \) \
       -exec rm -r {} \+

--- a/freyr.sh
+++ b/freyr.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-if [ "$DOCKER_DESKTOP" == "true" ]; then
+if [ "$DOCKER_DESKTOP" = "true" ]; then
   COLS=$(stty size | cut -d" " -f2)
   (
     echo
@@ -12,8 +12,8 @@ if [ "$DOCKER_DESKTOP" == "true" ]; then
     echo "└────────────────────────────────────────────────────────────┘"
   ) | (
     while read -r line; do
-      printf "%*s" "$(((${COLS}-${#line})/2))" ""
-      echo "${line}"
+      printf "%*s" "$(((COLS-${#line})/2))" ""
+      echo "$line"
     done
   )
 

--- a/freyr.sh
+++ b/freyr.sh
@@ -12,7 +12,7 @@ if [ "$DOCKER_DESKTOP" = "true" ]; then
     echo "└────────────────────────────────────────────────────────────┘"
   ) | (
     while read -r line; do
-      printf "%*s" "$(((COLS-${#line})/2))" ""
+      printf "%*s" "$(((COLS - ${#line}) / 2))" ""
       echo "$line"
     done
   )

--- a/freyr.sh
+++ b/freyr.sh
@@ -1,3 +1,23 @@
 #!/bin/sh
 
+if [ "$DOCKER_DESKTOP" == "true" ]; then
+  (
+    echo
+    echo
+    echo
+    echo "┌────────────────────────────────────────────────────────────┐"
+    echo "│      You are running freyr from inside Docker Desktop      │"
+    echo "│  Click on the CLI button at the top right to access a CLI  │"
+    echo "└────────────────────────────────────────────────────────────┘"
+  ) | (
+    COLS=$(tput cols)
+    while read -r line; do
+      printf "%*s" "$(((${COLS}-${#line})/2))";
+      echo "${line}"
+    done
+  )
+
+  tail -f /dev/null
+fi
+
 node "$(dirname "$0")"/cli.js "$@"

--- a/freyr.sh
+++ b/freyr.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 if [ "$DOCKER_DESKTOP" == "true" ]; then
+  COLS=$(stty size | cut -d" " -f2)
   (
     echo
     echo
@@ -10,9 +11,8 @@ if [ "$DOCKER_DESKTOP" == "true" ]; then
     echo "│  Click on the CLI button at the top right to access a CLI  │"
     echo "└────────────────────────────────────────────────────────────┘"
   ) | (
-    COLS=$(tput cols)
     while read -r line; do
-      printf "%*s" "$(((${COLS}-${#line})/2))";
+      printf "%*s" "$(((${COLS}-${#line})/2))" ""
       echo "${line}"
     done
   )


### PR DESCRIPTION
When running freyr from inside docker desktop, add the `DOCKER_DESKTOP=true` environment variable.

That tells freyr to fall into shell mode.

Once in shell mode, you can run the `freyr` command directly.

Fixes #313.