### PR TITLE
Mutual exclusion for file writes

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -759,11 +759,11 @@ async function init(packageJson, queries, options) {
 
         feed.setHeadHandler(async ({acceptsRanges}) => {
           let [offset, writeStream] = [];
-          if (acceptsRanges) await maybeStat(outputFile).then(({size}) => (offset = size));
+          if (acceptsRanges) await maybeStat(outputFile.path).then(({size}) => (offset = size));
           if (offset) {
             opts.resumeHandler(offset);
-            writeStream = createWriteStream(outputFile, {flags: 'a'});
-          } else writeStream = createWriteStream(outputFile, {flags: 'w'});
+            writeStream = createWriteStream(null, {fd: outputFile.handle, flags: 'a'});
+          } else writeStream = createWriteStream(null, {fd: outputFile.handle, flags: 'w'});
           feed.pipe(writeStream).on('finish', () => ((completed = true), res(writeStream.bytesWritten)));
           return offset;
         });
@@ -781,7 +781,7 @@ async function init(packageJson, queries, options) {
         } else logger.write(opts.altMessage());
 
         let has_erred = false;
-        const writeStream = createWriteStream(outputFile);
+        const writeStream = createWriteStream(null, {fd: outputFile.handle, flags: 'w'});
 
         merge2(
           ...urlOrFragments.map((frag, i) => {
@@ -839,84 +839,94 @@ async function init(packageJson, queries, options) {
     async ({track, meta, feedMeta, trackLogger}) => {
       const baseCacheDir = 'fr3yrcach3';
 
-      const imageFile = await fileMgr({
-        filename: `freyrcli-${meta.fingerprint}.x4i`,
-        tempdir: Config.dirs.cacheDir === '<tmp>' ? undefined : Config.dirs.cacheDir,
-        dirname: baseCacheDir,
-        keep: true,
-      });
-
+      let imageFile;
       let imageBytesWritten = 0;
       try {
-        imageBytesWritten = await downloadToStream({
-          urlOrFragments: track.getImage(Config.image.width, Config.image.height),
-          outputFile: imageFile.path,
-          logger: trackLogger,
-          opts: {
-            tag: '[Retrieving album art]...',
-            retryMessage: data => trackLogger.getText(`| ${getRetryMessage(data)}`),
-            resumeHandler: offset =>
-              trackLogger.log(cStringd(`| :{color(yellow)}{i}:{color:close(yellow)} Resuming at ${offset}`)),
-            failureMessage: err =>
-              trackLogger.getText(`| [\u2715] Failed to get album art${err ? ` [${err.code || err.message}]` : ''}`),
-            successMessage: trackLogger.getText(`| [\u2713] Got album art`),
-            altMessage: trackLogger.getText('| \u27a4 Downloading album art...'),
-          },
-        });
-      } catch (err) {
-        await imageFile.removeCallback();
-        throw {err, [symbols.errorCode]: 3};
-      }
-
-      const rawAudio = await fileMgr({
-        filename: `freyrcli-${meta.fingerprint}.x4a`,
-        tempdir: Config.dirs.cacheDir === '<tmp>' ? undefined : Config.dirs.cacheDir,
-        dirname: baseCacheDir,
-        keep: true,
-      });
-
-      let audioBytesWritten = 0;
-      try {
-        audioBytesWritten = await downloadToStream(
-          _merge(
-            {
-              outputFile: rawAudio.path,
+        imageFile = await fileMgr({
+          filename: `freyrcli-${meta.fingerprint}.x4i`,
+          tempdir: Config.dirs.cacheDir === '<tmp>' ? undefined : Config.dirs.cacheDir,
+          dirname: baseCacheDir,
+          keep: true,
+        }).writeOnce(async imageFile => {
+          try {
+            imageBytesWritten = await downloadToStream({
+              urlOrFragments: track.getImage(Config.image.width, Config.image.height),
+              outputFile: imageFile,
               logger: trackLogger,
               opts: {
-                tag: `[‘${meta.trackName}’]`,
+                tag: '[Retrieving album art]...',
                 retryMessage: data => trackLogger.getText(`| ${getRetryMessage(data)}`),
                 resumeHandler: offset =>
                   trackLogger.log(cStringd(`| :{color(yellow)}{i}:{color:close(yellow)} Resuming at ${offset}`)),
-                successMessage: trackLogger.getText('| [\u2713] Got raw track file'),
-                altMessage: trackLogger.getText('| \u27a4 Downloading track...'),
+                failureMessage: err =>
+                  trackLogger.getText(`| [\u2715] Failed to get album art${err ? ` [${err.code || err.message}]` : ''}`),
+                successMessage: trackLogger.getText(`| [\u2713] Got album art`),
+                altMessage: trackLogger.getText('| \u27a4 Downloading album art...'),
               },
-            },
-            feedMeta.protocol !== 'http_dash_segments'
-              ? {
-                  urlOrFragments: feedMeta.url,
+            });
+          } catch (err) {
+            await imageFile.removeCallback();
+            throw err;
+          }
+        });
+      } catch (err) {
+        throw {err, [symbols.errorCode]: 3};
+      }
+
+      let rawAudio;
+      let audioBytesWritten = 0;
+      try {
+        rawAudio = await fileMgr({
+          filename: `freyrcli-${meta.fingerprint}.x4a`,
+          tempdir: Config.dirs.cacheDir === '<tmp>' ? undefined : Config.dirs.cacheDir,
+          dirname: baseCacheDir,
+          keep: true,
+        }).writeOnce(async rawAudio => {
+          try {
+            audioBytesWritten = await downloadToStream(
+              _merge(
+                {
+                  outputFile: rawAudio,
+                  logger: trackLogger,
                   opts: {
-                    failureMessage: err =>
-                      trackLogger.getText(
-                        `| [\u2715] Failed to get raw media stream${err ? ` [${err.code || err.message}]` : ''}`,
-                      ),
-                  },
-                }
-              : {
-                  urlOrFragments: feedMeta.fragments.map(({path}) => ({
-                    url: `${feedMeta.fragment_base_url}${path}`,
-                    ...(([, min, max]) => ({min: +min, max: +max, size: +max - +min + 1}))(path.match(/range\/(\d+)-(\d+)$/)),
-                  })),
-                  opts: {
-                    failureMessage: err =>
-                      trackLogger.getText(
-                        `| [\u2715] Segment error while getting raw media${err ? ` [${err.code || err.message}]` : ''}`,
-                      ),
+                    tag: `[‘${meta.trackName}’]`,
+                    retryMessage: data => trackLogger.getText(`| ${getRetryMessage(data)}`),
+                    resumeHandler: offset =>
+                      trackLogger.log(cStringd(`| :{color(yellow)}{i}:{color:close(yellow)} Resuming at ${offset}`)),
+                    successMessage: trackLogger.getText('| [\u2713] Got raw track file'),
+                    altMessage: trackLogger.getText('| \u27a4 Downloading track...'),
                   },
                 },
-          ),
-        );
+                feedMeta.protocol !== 'http_dash_segments'
+                  ? {
+                      urlOrFragments: feedMeta.url,
+                      opts: {
+                        failureMessage: err =>
+                          trackLogger.getText(
+                            `| [\u2715] Failed to get raw media stream${err ? ` [${err.code || err.message}]` : ''}`,
+                          ),
+                      },
+                    }
+                  : {
+                      urlOrFragments: feedMeta.fragments.map(({path}) => ({
+                        url: `${feedMeta.fragment_base_url}${path}`,
+                        ...(([, min, max]) => ({min: +min, max: +max, size: +max - +min + 1}))(path.match(/range\/(\d+)-(\d+)$/)),
+                      })),
+                      opts: {
+                        failureMessage: err =>
+                          trackLogger.getText(
+                            `| [\u2715] Segment error while getting raw media${err ? ` [${err.code || err.message}]` : ''}`,
+                          ),
+                      },
+                    },
+              ),
+            );
+          } catch (err) {
+            await rawAudio.removeCallback();
+            throw err;
+          }
+        });
       } catch (err) {
-        await rawAudio.removeCallback();
         throw {err, [symbols.errorCode]: 4};
       }
 

--- a/src/file_mgr.js
+++ b/src/file_mgr.js
@@ -6,6 +6,8 @@ import {promises as fs, constants as fs_constants} from 'fs';
 import mkdirp from 'mkdirp';
 import esMain from 'es-main';
 
+import symbols from './symbols.js';
+
 const openfiles = {};
 const removeCallbacks = [];
 
@@ -26,54 +28,80 @@ export function forgetAll() {
   garbageCollector({forget: true});
 }
 
-export default async function genFile(opts) {
-  opts = opts || {};
-  let mode = fs_constants.O_CREAT | opts.mode;
-  const path = resolve(join('tmpdir' in opts ? opts['tmpdir'] : tmpdir(), opts.dirname || '.', opts.filename));
-  let id = createHash('md5').update(`Ξ${mode}${path}`).digest('hex');
-  let file = openfiles[id];
-  if (!file) {
-    await mkdirp(dirname(path));
-    file = openfiles[id] = {path, handle: null, refs: 1, closed: true, keep: false};
-  } else file.refs += 1;
-  if (file.closed) file.handle = await fs.open(path, mode);
-  hookupListeners();
-  const garbageHandler = async ({keep, forget = false} = {}) => {
-    file.keep ||= keep !== undefined ? keep : opts.keep;
-    if ((file.refs = Math.max(0, file.refs - 1))) return;
-    if (file.closed) return;
-    let handle = file.handle;
-    delete file.handle;
-    file.closed = true;
-    if (forget) delete openfiles[id];
-    await handle.close();
-    if (!file.keep) await fs.unlink(path);
+export default function genFile(opts) {
+  let inner = async mode => {
+    opts = opts || {};
+    mode = fs_constants.O_CREAT | mode;
+    const path = resolve(join('tmpdir' in opts ? opts['tmpdir'] : tmpdir(), opts.dirname || '.', opts.filename));
+    let id = createHash('md5').update(`Ξ${mode}${path}`).digest('hex');
+    let file = openfiles[id];
+    if (!file) {
+      await mkdirp(dirname(path));
+      file = openfiles[id] = {path, handle: null, refs: 1, closed: true, keep: false, writer: null};
+    } else file.refs += 1;
+    if (file.closed) [file.closed, file.handle] = [false, await fs.open(path, mode)];
+    hookupListeners();
+    const garbageHandler = async ({keep, forget = false} = {}) => {
+      file.keep ||= keep !== undefined ? keep : opts.keep;
+      if ((file.refs = Math.max(0, file.refs - 1))) return;
+      if (file.closed) return;
+      let handle = file.handle;
+      delete file.handle;
+      file.closed = true;
+      if (forget) delete openfiles[id];
+      await handle.close();
+      if (!file.keep) await fs.unlink(path);
+    };
+    removeCallbacks.push(garbageHandler);
+    return {
+      [symbols.fileId]: id,
+      path,
+      handle: file.handle,
+      removeCallback: async args => {
+        await garbageHandler({...args, keep: false});
+        removeCallbacks.splice(removeCallbacks.indexOf(garbageHandler), 1);
+      },
+    };
   };
-  removeCallbacks.push(garbageHandler);
-  return {
-    path,
-    handle: file.handle,
-    removeCallback: async args => {
-      await garbageHandler({...args, keep: false});
-      removeCallbacks.splice(removeCallbacks.indexOf(garbageHandler), 1);
+  let methods = {
+    read: () => inner(fs_constants.O_RDONLY),
+    /** File will be written to once, unless forcefully forgotten. */
+    writeOnce: async writerGen => {
+      let fileRef = await inner(fs_constants.O_WRONLY);
+      let file = openfiles[fileRef[symbols.fileId]];
+      await (file.writer ||= fileRef.writer = writerGen(fileRef));
+      return fileRef;
     },
+    open: inner,
+    write: () => Promise.reject(new Error('not yet implemented')),
   };
+  let used = false;
+  return Object.fromEntries(
+    Object.entries(methods).map(([name, fn]) => [
+      name,
+      async (...args) => {
+        if (used) throw new Error(`A FileReference can only be used once`);
+        used = true;
+        return await fn(...args);
+      },
+    ]),
+  );
 }
 
 async function test() {
   const filename = 'freyr_mgr_temp_file';
   async function testMgr(args) {
-    const file = await genFile({filename, ...args});
+    const file = await genFile({filename, ...args}).read();
     console.log('mgr>', file);
     return file;
   }
   let a = await testMgr();
   let b = await testMgr();
-  await testMgr({keep: true});
+  let _c = await testMgr({keep: true});
   let d = await testMgr();
   a.removeCallback();
   b.removeCallback();
-  // c.removeCallback(); // calling this would negate the keep directive
+  // _c.removeCallback(); // calling this would negate the keep directive
   d.removeCallback();
 }
 

--- a/src/file_mgr.js
+++ b/src/file_mgr.js
@@ -33,7 +33,7 @@ export default function genFile(opts) {
     if ('tmpdir' in opts && opts.path) throw new Error('Cannot specify path and tmpdir');
     opts = Object.assign({path: null, filename: null, dirname: null, tmpdir: true, keep: false}, opts);
     if (opts.path && (opts.filename || opts.dirname)) throw new Error('Cannot specify path and either filename or dirname');
-    if (!(opts.path || opts.filename)) opts.filename = crypto.randomBytes(8).toString('hex');
+    if (!(opts.path || opts.filename)) opts.filename = randomBytes(8).toString('hex');
     if (opts.tmpdir)
       if (opts.dirname) opts.dirname = join(tmpdir(), opts.dirname);
       else opts.dirname = tmpdir();

--- a/src/symbols.js
+++ b/src/symbols.js
@@ -1,9 +1,11 @@
 const meta = Symbol('FreyrServiceMeta');
+const fileId = Symbol('FreyrFileId');
 const errorCode = Symbol('FreyrErrorCode');
 const errorStack = Symbol('FreyrErrorStack');
 
 export default {
   meta,
+  fileId,
   errorCode,
   errorStack,
 };

--- a/test/index.js
+++ b/test/index.js
@@ -114,8 +114,7 @@ async function run_tests(suite, args, i) {
         filename: `${service}-${type}-${attempt}.log`,
         tmpdir: test_stage_path,
         keep: true,
-        mode: fs_constants.W_OK,
-      });
+      }).open(fs_constants.W_OK);
 
       logFile.stream = createWriteStream(null, {fd: logFile.handle});
 

--- a/test/index.js
+++ b/test/index.js
@@ -111,8 +111,7 @@ async function run_tests(suite, args, i) {
       if (attempt > 1 && lastErr !== unmetExpectations) abort();
 
       let logFile = await fileMgr({
-        filename: `${service}-${type}-${attempt}.log`,
-        tmpdir: test_stage_path,
+        path: join(test_stage_path, `${service}-${type}-${attempt}.log`),
         keep: true,
       }).open(fs_constants.W_OK);
 


### PR DESCRIPTION
Could be the case that a playlist, or an artist with two identical albums have identical tracks. Freyr, resolving them to the same source, ends up downloading the track to the same cache stage, encoding and writing it out to the same output file.

Lots of potential for clashes, and race conditions. At the end of the day, the file may end up corrupt.

It's a game of russian roulette, basically.

This patch makes it so, a file is only ever touched by freyr once in the entire lifetime of the program's execution.

So if a track is being downloaded by being on another album, that download task carries through for the whole program.

And if they're writing to the same file, well, only one gets to do the writing.