### PR TITLE
hide stty error message when docker is run without an attached tty

### DIFF
--- a/freyr.sh
+++ b/freyr.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 if [ "$DOCKER_DESKTOP" = "true" ]; then
-  COLS=$(stty size | cut -d" " -f2)
+  COLS=$(stty size 2>&- | cut -d" " -f2)
   (
     echo
     echo


### PR DESCRIPTION
<img width="564" alt="CleanShot 2022-09-17 at 07 04 17@2x" src="https://user-images.githubusercontent.com/16881812/190838231-87a84be3-f8a0-40c9-a015-4b549576f210.png">
