### PR TITLE
Apple Music: Add Pagination

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -71,6 +71,7 @@ jobs:
     if: ${{ always() }}
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         service:
           - { id: spotify, name: Spotify }

--- a/src/services/apple_music.js
+++ b/src/services/apple_music.js
@@ -246,13 +246,13 @@ export default class AppleMusic {
         storefront,
       );
       return Promise.mapSeries(tracks, async track => {
-        track.artist = await this.depaginate(track.relationships.artists, nextUrl => {
+        track.artists = await this.depaginate(track.relationships.artists, nextUrl => {
           let err = new Error('Unimplemented: track artists pagination');
           [err.trackId, err.trackHref, err.nextUrl] = [track.id, track.href, nextUrl];
           throw err;
           // this.#store.core.tracks.get(`${track.id}/${nextUrl.split(track.href)[1]}`, {storefront});
         });
-        track.album = await this.depaginate(track.relationships.albums, nextUrl => {
+        track.albums = await this.depaginate(track.relationships.albums, nextUrl => {
           let err = new Error('Unimplemented: track albums pagination');
           [err.trackId, err.trackHref, err.nextUrl] = [track.id, track.href, nextUrl];
           throw err;
@@ -295,7 +295,7 @@ export default class AppleMusic {
       Promise.mapSeries(
         (await this.#store.core.artists.get(`?ids=${items.map(item => item.refID).join(',')}`, {storefront})).data,
         async artist => {
-          artist.album = await this.depaginate(artist.relationships.albums, nextUrl => {
+          artist.albums = await this.depaginate(artist.relationships.albums, nextUrl => {
             let err = new Error('Unimplemented: artist albums pagination');
             [err.artistId, err.artistHref, err.nextUrl] = [artist.id, artist.href, nextUrl];
             throw err;

--- a/src/services/apple_music.js
+++ b/src/services/apple_music.js
@@ -300,15 +300,9 @@ export default class AppleMusic {
   }
 
   async getArtistAlbums(uris, store) {
-    return this.processData(
+    return this.getAlbum(
       (await this.getArtist(uris)).albums.map(album => `apple_music:album:${album}`),
-      100,
       store,
-      (items, storefront) =>
-        this.getAlbum(
-          items.map(item => item.uri),
-          storefront,
-        ),
     );
   }
 }

--- a/src/services/apple_music.js
+++ b/src/services/apple_music.js
@@ -245,13 +245,13 @@ export default class AppleMusic {
         storefront,
       );
       return Promise.mapSeries(tracks, async track => {
-        track.artist = await this.depaginate(track.relationships.artist, nextUrl => {
+        track.artist = await this.depaginate(track.relationships.artists, nextUrl => {
           let err = new Error('Unimplemented: track artists pagination');
           [err.trackId, err.trackHref, err.nextUrl] = [track.id, track.href, nextUrl];
           throw err;
           // this.#store.core.tracks.get(`${track.id}/${nextUrl.split(track.href)[1]}`, {storefront});
         });
-        track.album = await this.depaginate(track.relationships.album, nextUrl => {
+        track.album = await this.depaginate(track.relationships.albums, nextUrl => {
           let err = new Error('Unimplemented: track albums pagination');
           [err.trackId, err.trackHref, err.nextUrl] = [track.id, track.href, nextUrl];
           throw err;
@@ -294,7 +294,7 @@ export default class AppleMusic {
       Promise.mapSeries(
         (await this.#store.core.artists.get(`?ids=${items.map(item => item.refID).join(',')}`, {storefront})).data,
         async artist => {
-          artist.album = await this.depaginate(artist.relationships.album, nextUrl => {
+          artist.album = await this.depaginate(artist.relationships.albums, nextUrl => {
             let err = new Error('Unimplemented: artist albums pagination');
             [err.artistId, err.artistHref, err.nextUrl] = [artist.id, artist.href, nextUrl];
             throw err;


### PR DESCRIPTION
Fixes #177.

Test Cases:
 - From the original issue: https://music.apple.com/us/playlist/music3/pl.u-55D6X83H8lWGzjB
 - And this 331-track playlist: https://music.apple.com/us/playlist/this-is-the-longest-playlist-ever/pl.u-d2b05b2uMv8Algy