### PR TITLE
cleanup any provisioned resources

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -1130,7 +1130,8 @@ async function init(packageJson, queries, options) {
     'cli:postprocessor:encodeQueue',
     Config.concurrency.encoder,
     AsyncQueue.provision(
-      async () => {
+      async (cleanup, resource) => {
+        if (cleanup) return resource.exit();
         let ffmpeg = createFFmpeg({log: false});
         await ffmpeg.load();
         return ffmpeg;
@@ -1690,6 +1691,7 @@ async function init(packageJson, queries, options) {
     stackLogger.log('===============================');
   }
   await fileMgr.garbageCollect({keep: Config.dirs.cache.keep});
+  await encodeQueue.cleanup();
 }
 
 function prepCli(packageJson) {


### PR DESCRIPTION
As it should be, but also because, as observed in #370, `ffmpeg-wasm` now requires an explicit call to `ffmpeg.exit` which we can only do after freyr is done with it.