### PR TITLE
allow NODE_ARGS input when using a Docker image for testing

### DIFF
--- a/freyr.sh
+++ b/freyr.sh
@@ -20,4 +20,4 @@ if [ "$DOCKER_DESKTOP" = "true" ]; then
   tail -f /dev/null
 fi
 
-node ${FREYR_NODE_ARGS[@]} -- "$(dirname "$0")"/cli.js "$@"
+node "${FREYR_NODE_ARGS[@]}" -- "$(dirname "$0")"/cli.js "$@"

--- a/freyr.sh
+++ b/freyr.sh
@@ -20,4 +20,4 @@ if [ "$DOCKER_DESKTOP" = "true" ]; then
   tail -f /dev/null
 fi
 
-node "$(dirname "$0")"/cli.js "$@"
+node $NODE_ARGS "$(dirname "$0")"/cli.js "$@"

--- a/freyr.sh
+++ b/freyr.sh
@@ -20,4 +20,4 @@ if [ "$DOCKER_DESKTOP" = "true" ]; then
   tail -f /dev/null
 fi
 
-node $NODE_ARGS "$(dirname "$0")"/cli.js "$@"
+node $FREYR_NODE_ARGS -- "$(dirname "$0")"/cli.js "$@"

--- a/freyr.sh
+++ b/freyr.sh
@@ -20,4 +20,4 @@ if [ "$DOCKER_DESKTOP" = "true" ]; then
   tail -f /dev/null
 fi
 
-node $FREYR_NODE_ARGS -- "$(dirname "$0")"/cli.js "$@"
+node ${FREYR_NODE_ARGS[@]} -- "$(dirname "$0")"/cli.js "$@"

--- a/test/index.js
+++ b/test/index.js
@@ -142,8 +142,8 @@ async function run_tests(suite, args, i) {
       let child,
         handler = () => {};
 
+      let extra_node_args = process.env['NODE_ARGS'] ? process.env['NODE_ARGS'].split(' ') : [];
       if (!docker_image) {
-        let extra_node_args = process.env['NODE_ARGS'] ? process.env['NODE_ARGS'].split(' ') : [];
         child = spawn(
           'node',
           [
@@ -174,6 +174,7 @@ async function run_tests(suite, args, i) {
           `${test_stage_path}:/data`,
           '--env',
           'SHOW_DEBUG_STACK=1',
+          ...(extra_node_args.length ? ['--env', `NODE_ARGS=${extra_node_args.join(' ')}`] : []),
           '--',
           docker_image,
           ...child_args,

--- a/test/index.js
+++ b/test/index.js
@@ -174,7 +174,7 @@ async function run_tests(suite, args, i) {
           `${test_stage_path}:/data`,
           '--env',
           'SHOW_DEBUG_STACK=1',
-          ...(extra_node_args.length ? ['--env', `NODE_ARGS=${extra_node_args.join(' ')}`] : []),
+          ...(extra_node_args.length ? ['--env', `FREYR_NODE_ARGS=${extra_node_args.join(' ')}`] : []),
           '--',
           docker_image,
           ...child_args,


### PR DESCRIPTION
Since the docker image is launched with `--network host`, we can also forward arguments defined in `NODE_ARGS`.

Part of https://github.com/miraclx/freyr-js/pull/372.

Let's us do:

```console
$ NODE_ARGS="--inspect" yarn test spotify.track --docker freyrcli/freyrjs-git:master
```