### PR TITLE
docker: switch shell to bash

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,10 +21,10 @@ RUN go install github.com/tj/node-prune@1159d4c \
 FROM alpine:3.16.2 as base
 
 # hadolint ignore=DL3018
-RUN apk add --no-cache nodejs python3 \
+RUN apk add --no-cache bash nodejs python3 \
   && find /usr/lib/python3* \
-      \( -type d -name __pycache__ -o -type f -name '*.whl' \) \
-      -exec rm -r {} \+
+  \( -type d -name __pycache__ -o -type f -name '*.whl' \) \
+  -exec rm -r {} \+
 COPY --from=prep /atomicparsley/AtomicParsley /bin/AtomicParsley
 
 COPY . /freyr

--- a/freyr.sh
+++ b/freyr.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 if [ "$DOCKER_DESKTOP" = "true" ]; then
   COLS=$(stty size 2>&- | cut -d" " -f2)


### PR DESCRIPTION
Switch shell to bash to allow for things like arrays in the freyr.sh script and more...