### PR TITLE
chore: fix regexes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Fix bug with Apple Music's URI parser. <https://github.com/miraclx/freyr-js/pull/403>
+
 ## [0.9.0] - 2022-12-18
 
 - BREAKING: replaced `-D, --downloader` with `-S, --source`, introduced the `-D, --check-dir` flag. <https://github.com/miraclx/freyr-js/pull/350>

--- a/src/services/apple_music.js
+++ b/src/services/apple_music.js
@@ -19,9 +19,9 @@ export default class AppleMusic {
       isSearchable: false,
       isSourceable: false,
     },
-    // https://www.debuggex.com/r/BcVR1cjFQmNgJn-E
+    // https://www.debuggex.com/r/nbRgm3fyDn2oampX
     VALID_URL:
-      /(?:(?:(?:(?:https?:\/\/)?(?:www\.)?)(?:(?:music|(?:geo\.itunes))\.apple.com)\/([a-z]{2})\/(album|artist|playlist)\/([^/]+)\/.+)|(?:apple_music:(track|album|artist|playlist):(.+)))/,
+      /(?:(?:(?:(?:https?:\/\/)?(?:www\.)?)(?:(?:music|(?:geo\.itunes))\.apple.com)\/([a-z]{2})\/(album|artist|playlist)\/(?:([^/]+)\/)?\w+)|(?:apple_music:(track|album|artist|playlist):(\w+)))/,
     PROP_SCHEMA: {},
   };
 

--- a/src/services/deezer.js
+++ b/src/services/deezer.js
@@ -125,7 +125,7 @@ export default class Deezer {
     },
     // https://www.debuggex.com/r/IuFIxSZGFJ07tOkR
     VALID_URL:
-      /(?:(?:(?:https?:\/\/)?(?:www\.)?)deezer.com(?:\/[a-z]{2})?\/(track|album|artist|playlist)\/(.+))|(?:deezer:(track|album|artist|playlist):(.+))/,
+      /(?:(?:(?:https?:\/\/)?(?:www\.)?)deezer.com(?:\/[a-z]{2})?\/(track|album|artist|playlist)\/(\d+))|(?:deezer:(track|album|artist|playlist):(\d+))/,
     PROP_SCHEMA: {},
   };
 

--- a/test/default.json
+++ b/test/default.json
@@ -50,11 +50,11 @@
       ]
     },
     "album": {
-      "uri": "https://music.apple.com/us/album/im-sorry-im-not-sorry-ep/1491795443",
+      "uri": "https://music.apple.com/de/album/1581087024?l=en",
       "expect": [
         "[•] Collation Complete",
-        "[•] Total tracks: [04]",
-        "✓ Passed:  [04]",
+        "[•] Total tracks: [14]",
+        "✓ Passed:  [14]",
         "✕ Failed:  [00]"
       ]
     },

--- a/test/default.json
+++ b/test/default.json
@@ -50,7 +50,7 @@
       ]
     },
     "album": {
-      "uri": "https://music.apple.com/de/album/1581087024?l=en",
+      "uri": "https://music.apple.com/de/album/=/1581087024?l=en",
       "expect": [
         "[•] Collation Complete",
         "[•] Total tracks: [14]",

--- a/test/default.json
+++ b/test/default.json
@@ -50,11 +50,11 @@
       ]
     },
     "album": {
-      "uri": "https://music.apple.com/de/album/=/1581087024?l=en",
+      "uri": "https://music.apple.com/us/album/im-sorry-im-not-sorry-ep/1491795443",
       "expect": [
         "[•] Collation Complete",
-        "[•] Total tracks: [14]",
-        "✓ Passed:  [14]",
+        "[•] Total tracks: [04]",
+        "✓ Passed:  [04]",
         "✕ Failed:  [00]"
       ]
     },


### PR DESCRIPTION
Apple Music: Support album urls that don't include the album name. ex. `https://music.apple.com/de/album/1581087024?l=en` As in #402.
Deezer: Restrict ID validity to numbers only. As it should've been.

Fixes #402.