### PR TITLE
chore: update youtube-dl-exec

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,8 @@
 FROM node:19.4.0-alpine3.16 as installer
 
-RUN printf '#!/usr/bin/env sh\necho "Python 3.7.0"\n' > /usr/bin/python3 && chmod +x /usr/bin/python3
-# ^-- Workaround to bypass youtube-dl-exec's postinstall check for a supported python installation
 COPY package.json yarn.lock /freyr/
 WORKDIR /freyr
+ARG YOUTUBE_DL_SKIP_PYTHON_CHECK=1
 RUN yarn install --prod --frozen-lockfile
 
 FROM golang:1.19.5-alpine3.16 as prep

--- a/cli.js
+++ b/cli.js
@@ -1035,13 +1035,13 @@ async function init(packageJson, queries, options) {
                       },
                     }
                   : {
-                      urlOrFragments: feedMeta.fragments.map(({url}) => ({
-                        url,
+                      urlOrFragments: feedMeta.fragments.map(({url, path}) => ({
+                        url: url ?? `${feedMeta.fragment_base_url}${path}`,
                         ...(([, min, max]) => ({
                           min: +min,
                           max: +max,
                           size: +max - +min + 1,
-                        }))(url.match(/range=(\d+)-(\d+)$/)),
+                        }))(path?.match(/range\/(\d+)-(\d+)$/) ?? url.match(/range=(\d+)-(\d+)$/)),
                       })),
                       opts: {
                         failureMessage: err =>

--- a/cli.js
+++ b/cli.js
@@ -1035,13 +1035,13 @@ async function init(packageJson, queries, options) {
                       },
                     }
                   : {
-                      urlOrFragments: feedMeta.fragments.map(({path}) => ({
-                        url: `${feedMeta.fragment_base_url}${path}`,
+                      urlOrFragments: feedMeta.fragments.map(({url}) => ({
+                        url,
                         ...(([, min, max]) => ({
                           min: +min,
                           max: +max,
                           size: +max - +min + 1,
-                        }))(path.match(/range\/(\d+)-(\d+)$/)),
+                        }))(url.match(/range=(\d+)-(\d+)$/)),
                       })),
                       opts: {
                         failureMessage: err =>

--- a/conf.json
+++ b/conf.json
@@ -56,7 +56,7 @@
     },
     "apple_music": {
       "storefront": "us",
-      "developerToken": "eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6IldlYlBsYXlLaWQifQ.eyJpc3MiOiJBTVBXZWJQbGF5IiwiaWF0IjoxNjcwNTI1ODE3LCJleHAiOjE2Nzc3ODM0MTcsInJvb3RfaHR0cHNfb3JpZ2luIjpbImFwcGxlLmNvbSJdfQ.tFyTOcl2TTRhXvNYZUUrrnxAiuRFyyk6UTmKWz-58o5h8JnUWb1_llZiJ4YBc_3AMfM2o6x85jTX1mBGDNuQ2A"
+      "developerToken": "eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6IldlYlBsYXlLaWQifQ.eyJpc3MiOiJBTVBXZWJQbGF5IiwiaWF0IjoxNjc4MzE5MTI4LCJleHAiOjE2ODU1NzY3MjgsInJvb3RfaHR0cHNfb3JpZ2luIjpbImFwcGxlLmNvbSJdfQ.xrwll_CfP29g7wKsk0L3jLRWiFgtpxc53n-YT1fCjFIkBsGYel7NKgRL4Zgv-6ehft-UG31_3gWlN2e0P8KLuw"
     },
     "deezer": {
       "retries": 2

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,7 @@
         "stripchar": "^1.2.1",
         "xbytes": "^1.8.0",
         "xprogress": "^0.19.1",
-        "youtube-dl-exec": "^2.1.4",
+        "youtube-dl-exec": "^2.4.0",
         "yt-search": "^2.10.3"
       },
       "bin": {
@@ -571,6 +571,37 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+    },
+    "node_modules/bin-version": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/bin-version/-/bin-version-6.0.0.tgz",
+      "integrity": "sha512-nk5wEsP4RiKjG+vF+uG8lFsEn4d7Y6FVDamzzftSunXOoOcOOkzcWdKVlGgFFwlUQCj63SgnUkLLGF8v7lufhw==",
+      "dependencies": {
+        "execa": "^5.0.0",
+        "find-versions": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/bin-version-check": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/bin-version-check/-/bin-version-check-5.0.0.tgz",
+      "integrity": "sha512-Q3FMQnS5eZmrBGqmDXLs4dbAn/f+52voP6ykJYmweSA60t6DyH4UTSwZhtbK5UH+LBoWvDljILUQMLRUtsynsA==",
+      "dependencies": {
+        "bin-version": "^6.0.0",
+        "semver": "^7.3.5",
+        "semver-truncate": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/bluebird": {
       "version": "3.7.2",
@@ -1935,6 +1966,20 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/find-versions": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/find-versions/-/find-versions-5.1.0.tgz",
+      "integrity": "sha512-+iwzCJ7C5v5KgcBuueqVoNiHVoQpwiUK5XFLjf0affFTep+Wcw93tPvmb8tqujDNmzhBDPddnWV/qgWSXgq+Hg==",
+      "dependencies": {
+        "semver-regex": "^4.0.5"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/flat-cache": {
@@ -3656,6 +3701,36 @@
         "node": ">=10"
       }
     },
+    "node_modules/semver-regex": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-4.0.5.tgz",
+      "integrity": "sha512-hunMQrEy1T6Jr2uEVjrAIqjwWcQTgOAcIM52C8MY1EZSD3DDNft04XzvYKPqjED65bNVVko0YI38nYeEHCX3yw==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/semver-truncate": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/semver-truncate/-/semver-truncate-2.0.0.tgz",
+      "integrity": "sha512-Rh266MLDYNeML5h90ttdMwfXe1+Nc4LAWd9X1KdJe8pPHP4kFmvLZALtsMNHNdvTyQygbEC0D59sIz47DIaq8w==",
+      "dependencies": {
+        "semver": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/semver-truncate/node_modules/semver": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
     "node_modules/send": {
       "version": "0.18.0",
       "resolved": "https://registry.npmjs.org/send/-/send-0.18.0.tgz",
@@ -3739,6 +3814,49 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.4.tgz",
       "integrity": "sha512-rqYhcAnZ6d/vTPGghdrw7iumdcbXpsk1b8IG/rz+VWV51DM0p7XCtMoJ3qhPLIbp3tvyt3pKRbaaEMZYpHto8Q=="
+    },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
     },
     "node_modules/speedometer": {
       "version": "1.1.0",
@@ -4255,16 +4373,16 @@
       }
     },
     "node_modules/youtube-dl-exec": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/youtube-dl-exec/-/youtube-dl-exec-2.1.4.tgz",
-      "integrity": "sha512-Kg8FCI1ITJ2G1TDDgQ5IKvvqgSp1Dfv81d+eweV8rw9uZzll5SruW2OHt6oYNE9xEWnBWgi9xBoMkmw9I3LfVg==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/youtube-dl-exec/-/youtube-dl-exec-2.4.0.tgz",
+      "integrity": "sha512-uHQzfhljFPyXZElSJ+YhKhWD11YdKDK+QTuRCp/22sOD8g3RE++uGti/kHFPV62DupEAWNq8XGoVaYyqsrEAyw==",
       "hasInstallScript": true,
       "dependencies": {
+        "bin-version-check": "~5.0.0",
         "dargs": "~7.0.0",
         "execa": "~5.1.0",
         "is-unix": "~2.0.1",
-        "mkdirp": "~1.0.4",
-        "node-fetch": "~2.6.5"
+        "simple-get": "~4.0.1"
       },
       "engines": {
         "node": ">= 14"
@@ -4724,6 +4842,25 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+    },
+    "bin-version": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/bin-version/-/bin-version-6.0.0.tgz",
+      "integrity": "sha512-nk5wEsP4RiKjG+vF+uG8lFsEn4d7Y6FVDamzzftSunXOoOcOOkzcWdKVlGgFFwlUQCj63SgnUkLLGF8v7lufhw==",
+      "requires": {
+        "execa": "^5.0.0",
+        "find-versions": "^5.0.0"
+      }
+    },
+    "bin-version-check": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/bin-version-check/-/bin-version-check-5.0.0.tgz",
+      "integrity": "sha512-Q3FMQnS5eZmrBGqmDXLs4dbAn/f+52voP6ykJYmweSA60t6DyH4UTSwZhtbK5UH+LBoWvDljILUQMLRUtsynsA==",
+      "requires": {
+        "bin-version": "^6.0.0",
+        "semver": "^7.3.5",
+        "semver-truncate": "^2.0.0"
+      }
     },
     "bluebird": {
       "version": "3.7.2",
@@ -5731,6 +5868,14 @@
       "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
       "requires": {
         "locate-path": "^3.0.0"
+      }
+    },
+    "find-versions": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/find-versions/-/find-versions-5.1.0.tgz",
+      "integrity": "sha512-+iwzCJ7C5v5KgcBuueqVoNiHVoQpwiUK5XFLjf0affFTep+Wcw93tPvmb8tqujDNmzhBDPddnWV/qgWSXgq+Hg==",
+      "requires": {
+        "semver-regex": "^4.0.5"
       }
     },
     "flat-cache": {
@@ -6947,6 +7092,26 @@
         "lru-cache": "^6.0.0"
       }
     },
+    "semver-regex": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-4.0.5.tgz",
+      "integrity": "sha512-hunMQrEy1T6Jr2uEVjrAIqjwWcQTgOAcIM52C8MY1EZSD3DDNft04XzvYKPqjED65bNVVko0YI38nYeEHCX3yw=="
+    },
+    "semver-truncate": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/semver-truncate/-/semver-truncate-2.0.0.tgz",
+      "integrity": "sha512-Rh266MLDYNeML5h90ttdMwfXe1+Nc4LAWd9X1KdJe8pPHP4kFmvLZALtsMNHNdvTyQygbEC0D59sIz47DIaq8w==",
+      "requires": {
+        "semver": "^6.0.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+        }
+      }
+    },
     "send": {
       "version": "0.18.0",
       "resolved": "https://registry.npmjs.org/send/-/send-0.18.0.tgz",
@@ -7017,6 +7182,21 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.4.tgz",
       "integrity": "sha512-rqYhcAnZ6d/vTPGghdrw7iumdcbXpsk1b8IG/rz+VWV51DM0p7XCtMoJ3qhPLIbp3tvyt3pKRbaaEMZYpHto8Q=="
+    },
+    "simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q=="
+    },
+    "simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "requires": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
     },
     "speedometer": {
       "version": "1.1.0",
@@ -7396,15 +7576,15 @@
       "dev": true
     },
     "youtube-dl-exec": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/youtube-dl-exec/-/youtube-dl-exec-2.1.4.tgz",
-      "integrity": "sha512-Kg8FCI1ITJ2G1TDDgQ5IKvvqgSp1Dfv81d+eweV8rw9uZzll5SruW2OHt6oYNE9xEWnBWgi9xBoMkmw9I3LfVg==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/youtube-dl-exec/-/youtube-dl-exec-2.4.0.tgz",
+      "integrity": "sha512-uHQzfhljFPyXZElSJ+YhKhWD11YdKDK+QTuRCp/22sOD8g3RE++uGti/kHFPV62DupEAWNq8XGoVaYyqsrEAyw==",
       "requires": {
+        "bin-version-check": "~5.0.0",
         "dargs": "~7.0.0",
         "execa": "~5.1.0",
         "is-unix": "~2.0.1",
-        "mkdirp": "~1.0.4",
-        "node-fetch": "~2.6.5"
+        "simple-get": "~4.0.1"
       }
     },
     "yt-search": {

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "stripchar": "^1.2.1",
     "xbytes": "^1.8.0",
     "xprogress": "^0.19.1",
-    "youtube-dl-exec": "^2.1.4",
+    "youtube-dl-exec": "^2.4.0",
     "yt-search": "^2.10.3"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -335,6 +335,23 @@ balanced-match@^1.0.0:
   resolved "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
+bin-version-check@~5.0.0:
+  version "5.0.0"
+  resolved "https://registry.npmjs.org/bin-version-check/-/bin-version-check-5.0.0.tgz"
+  integrity sha512-Q3FMQnS5eZmrBGqmDXLs4dbAn/f+52voP6ykJYmweSA60t6DyH4UTSwZhtbK5UH+LBoWvDljILUQMLRUtsynsA==
+  dependencies:
+    bin-version "^6.0.0"
+    semver "^7.3.5"
+    semver-truncate "^2.0.0"
+
+bin-version@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.npmjs.org/bin-version/-/bin-version-6.0.0.tgz"
+  integrity sha512-nk5wEsP4RiKjG+vF+uG8lFsEn4d7Y6FVDamzzftSunXOoOcOOkzcWdKVlGgFFwlUQCj63SgnUkLLGF8v7lufhw==
+  dependencies:
+    execa "^5.0.0"
+    find-versions "^5.0.0"
+
 bluebird@^3.7.2:
   version "3.7.2"
   resolved "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz"
@@ -1001,7 +1018,7 @@ event-emitter@^0.3.5:
     d "1"
     es5-ext "~0.10.14"
 
-execa@~5.1.0:
+execa@^5.0.0, execa@~5.1.0:
   version "5.1.1"
   resolved "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz"
   integrity sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==
@@ -1149,6 +1166,13 @@ find-up@^5.0.0:
   dependencies:
     locate-path "^6.0.0"
     path-exists "^4.0.0"
+
+find-versions@^5.0.0:
+  version "5.1.0"
+  resolved "https://registry.npmjs.org/find-versions/-/find-versions-5.1.0.tgz"
+  integrity sha512-+iwzCJ7C5v5KgcBuueqVoNiHVoQpwiUK5XFLjf0affFTep+Wcw93tPvmb8tqujDNmzhBDPddnWV/qgWSXgq+Hg==
+  dependencies:
+    semver-regex "^4.0.5"
 
 flat-cache@^3.0.4:
   version "3.0.4"
@@ -1805,7 +1829,7 @@ minimist@~1.2.5:
   resolved "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz"
   integrity sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==
 
-mkdirp@^1.0.4, mkdirp@~1.0.4:
+mkdirp@^1.0.4:
   version "1.0.4"
   resolved "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
@@ -1847,7 +1871,7 @@ node-cache@^5.1.2:
   dependencies:
     clone "2.x"
 
-node-fetch@^2.6.1, node-fetch@~2.6.5:
+node-fetch@^2.6.1:
   version "2.6.7"
   resolved "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz"
   integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==
@@ -1859,7 +1883,7 @@ node-fzf@0.11.0, node-fzf@~0.5.1:
   resolved "https://registry.npmjs.org/node-fzf/-/node-fzf-0.11.0.tgz"
   integrity sha512-djlXFlrGSrGCHVHOr4iPRkfPuZXac6Elv0wBtKEJ383Dd/rj+9zaCu4JDZQVSGvoDRRSfJYL4roK9SLjTxeOIg==
   dependencies:
-    cli-color "~2.0.0"
+    cli-color "~1.2.0"
     keypress "~0.2.1"
     minimist "~1.2.5"
     redstar "0.0.2"
@@ -2280,6 +2304,23 @@ safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   resolved "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
+semver-regex@^4.0.5:
+  version "4.0.5"
+  resolved "https://registry.npmjs.org/semver-regex/-/semver-regex-4.0.5.tgz"
+  integrity sha512-hunMQrEy1T6Jr2uEVjrAIqjwWcQTgOAcIM52C8MY1EZSD3DDNft04XzvYKPqjED65bNVVko0YI38nYeEHCX3yw==
+
+semver-truncate@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/semver-truncate/-/semver-truncate-2.0.0.tgz"
+  integrity sha512-Rh266MLDYNeML5h90ttdMwfXe1+Nc4LAWd9X1KdJe8pPHP4kFmvLZALtsMNHNdvTyQygbEC0D59sIz47DIaq8w==
+  dependencies:
+    semver "^6.0.0"
+
+semver@^6.0.0:
+  version "6.3.0"
+  resolved "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz"
+  integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
+
 semver@^7.3.2, semver@^7.3.5:
   version "7.3.5"
   resolved "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz"
@@ -2346,6 +2387,20 @@ signal-exit@^3.0.2, signal-exit@^3.0.3:
   version "3.0.4"
   resolved "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.4.tgz"
   integrity sha512-rqYhcAnZ6d/vTPGghdrw7iumdcbXpsk1b8IG/rz+VWV51DM0p7XCtMoJ3qhPLIbp3tvyt3pKRbaaEMZYpHto8Q==
+
+simple-concat@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz"
+  integrity sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==
+
+simple-get@~4.0.1:
+  version "4.0.1"
+  resolved "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz"
+  integrity sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==
+  dependencies:
+    decompress-response "^6.0.0"
+    once "^1.3.1"
+    simple-concat "^1.0.0"
 
 speedometer@^1.1.0:
   version "1.1.0"
@@ -2686,16 +2741,16 @@ yocto-queue@^0.1.0:
   resolved "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
 
-youtube-dl-exec@^2.1.4:
-  version "2.1.4"
-  resolved "https://registry.npmjs.org/youtube-dl-exec/-/youtube-dl-exec-2.1.4.tgz"
-  integrity sha512-Kg8FCI1ITJ2G1TDDgQ5IKvvqgSp1Dfv81d+eweV8rw9uZzll5SruW2OHt6oYNE9xEWnBWgi9xBoMkmw9I3LfVg==
+youtube-dl-exec@^2.4.0:
+  version "2.4.0"
+  resolved "https://registry.npmjs.org/youtube-dl-exec/-/youtube-dl-exec-2.4.0.tgz"
+  integrity sha512-uHQzfhljFPyXZElSJ+YhKhWD11YdKDK+QTuRCp/22sOD8g3RE++uGti/kHFPV62DupEAWNq8XGoVaYyqsrEAyw==
   dependencies:
+    bin-version-check "~5.0.0"
     dargs "~7.0.0"
     execa "~5.1.0"
     is-unix "~2.0.1"
-    mkdirp "~1.0.4"
-    node-fetch "~2.6.5"
+    simple-get "~4.0.1"
 
 yt-search@^2.10.3:
   version "2.10.3"


### PR DESCRIPTION
Fixes https://github.com/miraclx/freyr-js/issues/436.

Updates youtube-dl-exec, which subsequently downloads the latest version of yt-dlp.

Notable changes:
- https://github.com/yt-dlp/yt-dlp/pull/3044 replaced `path` in the feeds to `url`.