### PR TITLE
fix: permit absence of copyright

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -1112,7 +1112,7 @@ async function init(packageJson, queries, options) {
           // ownr? <owner>
           purchaseDate: 'timestamp', // purd
           apID: 'cli@freyr.git', // apID
-          copyright: track.copyrights.sort(({type}) => (type === 'P' ? -1 : 1))[0].text, // cprt
+          copyright: track.copyrights.sort(({type}) => (type === 'P' ? -1 : 1))[0]?.text, // cprt
           encodingTool: `freyr-js cli v${packageJson.version}`, // ©too
           encodedBy: 'd3vc0dr', // ©enc
           artwork: files.image.file.path, // covr


### PR DESCRIPTION
Fixes #415.

In certain tracks like `spotify:track:2paWUJOeEHip8XWcRSz61t`, no copyright information is returned, this patch relaxes the logic to a more permissible one, omitting embedding copyright information in the case that we have none.