### PR TITLE
chore: add config migrations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "freyr",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "freyr",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@ffmpeg/core": "^0.11.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "freyr",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "A versatile, service-agnostic music downloader and manager",
   "exports": "./src/freyr.js",
   "type": "module",


### PR DESCRIPTION
https://github.com/miraclx/freyr-js/pull/455 modified the field names for Spotify credentials to camelCase as opposed to snake_case.

This patch makes it possible to migrate old versions of the config on existing users devices.

Fixes this (reported in https://github.com/miraclx/freyr-js/issues/466#issuecomment-1494451868)
```console
[!] Fatal Error: Config schema violation: `services/spotify` must NOT have additional properties; `services/spotify` must NOT have additional properties
```