### PR TITLE
chore: revisit YouTube Music track weighing logic

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -1226,7 +1226,12 @@ async function init(packageJson, queries, options) {
       const result = {service: null, sources: null, lastErr};
       if ((result.service = iterator.next().value)) {
         result.sources = Promise.resolve(
-          result.service.search(track.artists, track.name.replace(/\s*\((((feat|ft).)|with).+\)/, ''), track.duration),
+          result.service.search(
+            track.artists,
+            track.name.replace(/\s*\((((feat|ft).)|with).+\)/, ''),
+            track.album,
+            track.duration,
+          ),
         ).then(sources => {
           if ([undefined, null].includes(sources)) throw new Error(`incompatible source response. recieved [${sources}]`);
           // arrays returned from service source calls should have at least one item


### PR DESCRIPTION
In cases like `apple_music:track:1208190370` where there's only one word in the track name, with all artists squashed into one entry, the odds of weighing the correct track is 50%, which is far under the cut-off of 70%

This patch rewrites that logic to stop presupposing either the track has more than one word, or there's more than one artist.

Now, we're embedding the album as well in there, taking the minimum odds of success to 66%, but we undercut by just a bit at 65%.

Issue originally derived from https://github.com/miraclx/freyr-js/issues/395#issuecomment-1385146417.