### PR TITLE
fix(text-utils): normalize accented words

### DIFF
--- a/src/text_utils.js
+++ b/src/text_utils.js
@@ -24,7 +24,10 @@ function stripText(data) {
   return [
     ...new Set(
       data.reduce(
-        (all, text) => ((text = StripChar.RSspecChar(text)) ? all.concat([text.replace(/\s{2,}/g, ' ').toLowerCase()]) : all),
+        (all, text) =>
+          (text = StripChar.RSspecChar(text.normalize('NFD').replace(/\p{Diacritic}/gu, '')))
+            ? all.concat([text.replace(/\s{2,}/g, ' ').toLowerCase()])
+            : all,
         [],
       ),
     ),


### PR DESCRIPTION
In cases like `apple_music:track:1208190370` where the track name is "Solidarité", `StripChar.RSspecChar` treats the accented `é` as a non-alphanumeric character and strips it. Leaving "Solidarit" which leads to incorrect results.

This patch normalizes those inputs, which in the case of "Solidarité`, results in "Solidarite".

Issue originally derived from https://github.com/miraclx/freyr-js/issues/395#issuecomment-1385146417, #419.