### PR TITLE
chore: update AtomicParsley in Docker, update docs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,8 @@ COPY --from=installer /freyr/node_modules /freyr/node_modules
 RUN go install github.com/tj/node-prune@1159d4c \
   && node-prune --include '*.map' /freyr/node_modules \
   && node-prune /freyr/node_modules \
-  && git clone --branch 20210715.151551.e7ad03a --depth 1 https://github.com/wez/atomicparsley /atomicparsley \
+  # todo! revert to upstream when https://github.com/wez/atomicparsley/pull/63 is merged and a release is cut
+  && git clone --branch 20230114.175602.21bde60 --depth 1 https://github.com/miraclx/atomicparsley /atomicparsley \
   && cmake -S /atomicparsley -B /atomicparsley \
   && cmake --build /atomicparsley --config Release
 

--- a/README.md
+++ b/README.md
@@ -130,23 +130,23 @@ Here's a list of the metadata that freyr can extract from each streaming service
   </details>
 
   <details>
-  <summary>AtomicParsley >= (v0.9.6 | 20200701)</summary>
+  <summary>AtomicParsley >= 20230114</summary>
 
-  First, download the latest release for your individual platforms here <https://github.com/wez/atomicparsley/releases/latest>
+  First, download the latest release for your individual platforms here <https://github.com/miraclx/atomicparsley/releases/latest>
 
   Then;
 
   - Windows:
     - unzip and place the `AtomicParsley.exe` in your `PATH`.
     - or the `bins/windows` folder of this project directory. Create the folder(s) if they don't exist.
-  - Linux + macOS _(the brew package isn't recommended)_:
+  - Linux + macOS:
     - unzip and place the `AtomicParsley` in your `PATH`.
     - or the `bins/posix` folder of this project directory. Create the folder(s) if they don't exist.
   - Alternatively:
     - Debian: `sudo apt-get install atomicparsley`
     - Arch Linux: `sudo pacman -S atomicparsley`
     - Android (Termux): `apt install atomicparsley`
-    - Build from source: See [wez/AtomicParsley](https://github.com/wez/atomicparsley)
+    - Build from source: See [wez/AtomicParsley](https://github.com/miraclx/atomicparsley)
 
   </details>
 


### PR DESCRIPTION
Update `AtomicParsley`, following https://github.com/wez/atomicparsley/pull/63.

Revert to upstream when that patch is merged, and a new release is cut.