### PR TITLE
chore: version to 0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improved the YouTube Music track weighing logic, we should get 30% more accurate results. <https://github.com/miraclx/freyr-js/pull/472>
 - Freyr now supports paginated track artists. <https://github.com/miraclx/freyr-js/pull/471>
 - Accented words like `Solidarité` now get properly normalized, helping more accurate lookups. <https://github.com/miraclx/freyr-js/pull/473>
-- Fix bug with Apple Music's URI parser. <https://github.com/miraclx/freyr-js/pull/403>
+- Fix bug with Apple Music & Deezer URI parser. <https://github.com/miraclx/freyr-js/pull/403>, <https://github.com/miraclx/freyr-js/pull/549>
 - Freyr now treats binaries in `bins/{posix,windows}` as being of higher priority than those in `PATH`. <https://github.com/miraclx/freyr-js/pull/474>
 - Freyr now properly handles tracks that have no copyright information. <https://github.com/miraclx/freyr-js/pull/467>
 - Freyr now properly checks the base dir instead of the current working dir for existing tracks. <https://github.com/miraclx/freyr-js/pull/527>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,16 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.10.0] - 2023-06-20
 
-- Changed Spotify credentials, introduced migrations to mitigate any complications. <https://github.com/miraclx/freyr-js/pull/454>, <https://github.com/miraclx/freyr-js/pull/470>
+- Changed Spotify credentials, introduced migrations to mitigate any complications. <https://github.com/miraclx/freyr-js/pull/454>, <https://github.com/miraclx/freyr-js/pull/470>, <https://github.com/miraclx/freyr-js/pull/526>
 - Improved the YouTube Music track weighing logic, we should get 30% more accurate results. <https://github.com/miraclx/freyr-js/pull/472>
 - Freyr now supports paginated track artists. <https://github.com/miraclx/freyr-js/pull/471>
 - Accented words like `Solidarité` now get properly normalized, helping more accurate lookups. <https://github.com/miraclx/freyr-js/pull/473>
 - Fix bug with Apple Music's URI parser. <https://github.com/miraclx/freyr-js/pull/403>
 - Freyr now treats binaries in `bins/{posix,windows}` as being of higher priority than those in `PATH`. <https://github.com/miraclx/freyr-js/pull/474>
 - Freyr now properly handles tracks that have no copyright information. <https://github.com/miraclx/freyr-js/pull/467>
-- Freyr now auto-disables the progress bar when it detects the absence of a compatible TTY, avoiding errors wherever possible. <https://github.com/miraclx/freyr-js/pull/506/files>
+- Updated logic for extracting source feeds from yt-dlp's response. <https://github.com/miraclx/freyr-js/pull/515>
+- Freyr now auto-disables the progress bar when it detects the absence of a compatible TTY, avoiding errors wherever possible. <https://github.com/miraclx/freyr-js/pull/506>
 - Allow overriding the atomicparsley binary used with the `ATOMIC_PARSLEY_PATH` environment variable. <https://github.com/miraclx/freyr-js/pull/475>
 - Updated `AtomicParsley` in the Docker images, fixing a class of errors. <https://github.com/miraclx/freyr-js/pull/476>
+- Ignore yt-dlp warnings that could cause hard errors when parsing its response. <https://github.com/miraclx/freyr-js/pull/511>
+- Fixed YouTube accuracy calculation. <https://github.com/miraclx/freyr-js/pull/509>, <https://github.com/miraclx/freyr-js/pull/510>
 
 ## [0.9.0] - 2022-12-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix bug with Apple Music's URI parser. <https://github.com/miraclx/freyr-js/pull/403>
 - Freyr now treats binaries in `bins/{posix,windows}` as being of higher priority than those in `PATH`. <https://github.com/miraclx/freyr-js/pull/474>
 - Freyr now properly handles tracks that have no copyright information. <https://github.com/miraclx/freyr-js/pull/467>
+- Freyr now properly checks the base dir instead of the current working dir for existing tracks. <https://github.com/miraclx/freyr-js/pull/527>
 - Updated logic for extracting source feeds from yt-dlp's response. <https://github.com/miraclx/freyr-js/pull/515>
 - Freyr now auto-disables the progress bar when it detects the absence of a compatible TTY, avoiding errors wherever possible. <https://github.com/miraclx/freyr-js/pull/506>
 - Allow overriding the atomicparsley binary used with the `ATOMIC_PARSLEY_PATH` environment variable. <https://github.com/miraclx/freyr-js/pull/475>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.10.0] - 2023-06-20
+## [0.10.0] - 2023-08-08
 
 - Changed Spotify credentials, introduced migrations to mitigate any complications. <https://github.com/miraclx/freyr-js/pull/454>, <https://github.com/miraclx/freyr-js/pull/470>, <https://github.com/miraclx/freyr-js/pull/526>
 - Improved the YouTube Music track weighing logic, we should get 30% more accurate results. <https://github.com/miraclx/freyr-js/pull/472>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.0] - 2023-06-20
+
+- Changed Spotify credentials, introduced migrations to mitigate any complications. <https://github.com/miraclx/freyr-js/pull/454>, <https://github.com/miraclx/freyr-js/pull/470>
+- Improved the YouTube Music track weighing logic, we should get 30% more accurate results. <https://github.com/miraclx/freyr-js/pull/472>
+- Freyr now supports paginated track artists. <https://github.com/miraclx/freyr-js/pull/471>
+- Accented words like `Solidarité` now get properly normalized, helping more accurate lookups. <https://github.com/miraclx/freyr-js/pull/473>
 - Fix bug with Apple Music's URI parser. <https://github.com/miraclx/freyr-js/pull/403>
+- Freyr now treats binaries in `bins/{posix,windows}` as being of higher priority than those in `PATH`. <https://github.com/miraclx/freyr-js/pull/474>
+- Freyr now properly handles tracks that have no copyright information. <https://github.com/miraclx/freyr-js/pull/467>
+- Freyr now auto-disables the progress bar when it detects the absence of a compatible TTY, avoiding errors wherever possible. <https://github.com/miraclx/freyr-js/pull/506/files>
+- Allow overriding the atomicparsley binary used with the `ATOMIC_PARSLEY_PATH` environment variable. <https://github.com/miraclx/freyr-js/pull/475>
+- Updated `AtomicParsley` in the Docker images, fixing a class of errors. <https://github.com/miraclx/freyr-js/pull/476>
 
 ## [0.9.0] - 2022-12-18
 
@@ -82,7 +93,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 > Release Page: <https://github.com/miraclx/freyr-js/releases/tag/v0.5.0>
 
-[unreleased]: https://github.com/miraclx/freyr-js/compare/v0.9.0...HEAD
+[unreleased]: https://github.com/miraclx/freyr-js/compare/v0.10.0...HEAD
+[0.10.0]: https://github.com/miraclx/freyr-js/releases/compare/v0.9.0...v0.10.0
 [0.9.0]: https://github.com/miraclx/freyr-js/releases/compare/v0.8.1...v0.9.0
 [0.8.1]: https://github.com/miraclx/freyr-js/releases/compare/v0.8.0...v0.8.1
 [0.8.0]: https://github.com/miraclx/freyr-js/releases/compare/v0.7.0...v0.8.0

--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ Usage: freyr [options] [query...]
   / /_/ ___/ _ \/ / / / ___/
  / __/ /  /  __/ /_/ / /
 /_/ /_/   \___/\__, /_/
-              /____/ v0.9.0
+              /____/ v0.10.0
 
 freyr - (c) Miraculous Owonubi <omiraculous@gmail.com>
 ------------------------------------------------------
@@ -328,7 +328,7 @@ Info:
   / /_/ ___/ _ \/ / / / ___/
  / __/ /  /  __/ /_/ / /
 /_/ /_/   \___/\__, /_/
-              /____/ v0.9.0
+              /____/ v0.10.0
 
 freyr - (c) Miraculous Owonubi <omiraculous@gmail.com>
 -------------------------------------------------------------
@@ -389,7 +389,7 @@ Checking directory permissions...[done]
   / /_/ ___/ _ \/ / / / ___/
  / __/ /  /  __/ /_/ / /
 /_/ /_/   \___/\__, /_/
-              /____/ v0.9.0
+              /____/ v0.10.0
 
 freyr - (c) Miraculous Owonubi <omiraculous@gmail.com>
 -------------------------------------------------------------
@@ -474,7 +474,7 @@ Checking directory permissions...[done]
   / /_/ ___/ _ \/ / / / ___/
  / __/ /  /  __/ /_/ / /
 /_/ /_/   \___/\__, /_/
-              /____/ v0.9.0
+              /____/ v0.10.0
 
 freyr - (c) Miraculous Owonubi <omiraculous@gmail.com>
 -------------------------------------------------------------
@@ -1126,7 +1126,7 @@ For more information and documentation about docker, please refer to its officia
 
 ## License
 
-[Apache 2.0][license] © **Miraculous Owonubi** ([@miraclx][author-url]) \<omiraculous@gmail.com\>
+[Apache 2.0][license] © **Miraculous Owonubi** ([@miraclx][author-url]) \<<omiraculous@gmail.com>\>
 
 [license]:  LICENSE "Apache 2.0 License"
 [author-url]: https://github.com/miraclx

--- a/cli.js
+++ b/cli.js
@@ -630,7 +630,7 @@ async function init(packageJson, queries, options) {
       else stackLogger.print(`[•] Migrating config file from v${context.fromVersion} → v${context.toVersion}...`);
     },
     migrations: {
-      '0.9.1': store => {
+      '0.10.0': store => {
         let spotify = store.get('services.spotify');
         if (spotify.refresh_token) {
           spotify.refreshToken = spotify.refresh_token;

--- a/conf.json
+++ b/conf.json
@@ -54,7 +54,7 @@
     },
     "apple_music": {
       "storefront": "us",
-      "developerToken": "eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6IldlYlBsYXlLaWQifQ.eyJpc3MiOiJBTVBXZWJQbGF5IiwiaWF0IjoxNjg2ODU3MzYwLCJleHAiOjE2OTQxMTQ5NjAsInJvb3RfaHR0cHNfb3JpZ2luIjpbImFwcGxlLmNvbSJdfQ.p-w8E36TJT0zGhIsT_yWRJkouUIProcnx8OR4mXMHUUKUY-Evi4mmhpPam9ZINbmES3YIH1s7yc8PbCTKaALnQ"
+      "developerToken": "eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6IldlYlBsYXlLaWQifQ.eyJpc3MiOiJBTVBXZWJQbGF5IiwiaWF0IjoxNjkwNDA2ODM1LCJleHAiOjE2OTc2NjQ0MzUsInJvb3RfaHR0cHNfb3JpZ2luIjpbImFwcGxlLmNvbSJdfQ.seFShNhCiGuoj5qBOqECAoKBtKJF0wN-KaEj4HICJnExwXtnYabeb0jTSSrK1uez5b6XvYUOsx0pgARKm1AJQg"
     },
     "deezer": {
       "retries": 2

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "freyr",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "freyr",
-      "version": "0.9.1",
+      "version": "0.10.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@ffmpeg/core": "^0.11.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "freyr",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "description": "A versatile, service-agnostic music downloader and manager",
   "exports": "./src/freyr.js",
   "type": "module",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1957,7 +1957,7 @@ node-fzf@0.11.0, node-fzf@~0.5.1:
   resolved "https://registry.npmjs.org/node-fzf/-/node-fzf-0.11.0.tgz"
   integrity sha512-djlXFlrGSrGCHVHOr4iPRkfPuZXac6Elv0wBtKEJ383Dd/rj+9zaCu4JDZQVSGvoDRRSfJYL4roK9SLjTxeOIg==
   dependencies:
-    cli-color "~2.0.0"
+    cli-color "~1.2.0"
     keypress "~0.2.1"
     minimist "~1.2.5"
     redstar "0.0.2"


### PR DESCRIPTION
Scheduled release: 08-08-2023

Notable changes:

- Changed Spotify credentials, introduced migrations to mitigate any complications. <https://github.com/miraclx/freyr-js/pull/454>, <https://github.com/miraclx/freyr-js/pull/470>, <https://github.com/miraclx/freyr-js/pull/526>
- Improved the YouTube Music track weighing logic, we should get 30% more accurate results. <https://github.com/miraclx/freyr-js/pull/472>
- Freyr now supports paginated track artists. <https://github.com/miraclx/freyr-js/pull/471>
- Accented words like `Solidarité` now get properly normalized, helping more accurate lookups. <https://github.com/miraclx/freyr-js/pull/473>
- Fix bug with Apple Music & Deezer URI parser. <https://github.com/miraclx/freyr-js/pull/403>, <https://github.com/miraclx/freyr-js/pull/549>
- Freyr now treats binaries in `bins/{posix,windows}` as being of higher priority than those in `PATH`. <https://github.com/miraclx/freyr-js/pull/474>
- Freyr now properly handles tracks that have no copyright information. <https://github.com/miraclx/freyr-js/pull/467>
- Freyr now properly checks the base dir instead of the current working dir for existing tracks. <https://github.com/miraclx/freyr-js/pull/527>
- Updated logic for extracting source feeds from yt-dlp's response. <https://github.com/miraclx/freyr-js/pull/515>
- Freyr now auto-disables the progress bar when it detects the absence of a compatible TTY, avoiding errors wherever possible. <https://github.com/miraclx/freyr-js/pull/506>
- Allow overriding the atomicparsley binary used with the `ATOMIC_PARSLEY_PATH` environment variable. <https://github.com/miraclx/freyr-js/pull/475>
- Updated `AtomicParsley` in the Docker images, fixing a class of errors. <https://github.com/miraclx/freyr-js/pull/476>
- Ignore yt-dlp warnings that could cause hard errors when parsing its response. <https://github.com/miraclx/freyr-js/pull/511>
- Fixed YouTube accuracy calculation. <https://github.com/miraclx/freyr-js/pull/509>, <https://github.com/miraclx/freyr-js/pull/510>