### PR TITLE
fix(YouTube): ignore errors when we call out to yt-dlp

### DIFF
--- a/src/services/youtube.js
+++ b/src/services/youtube.js
@@ -58,6 +58,7 @@ function genAsyncGetFeedsFn(url) {
       socketTimeout: 20,
       cacheDir: false,
       dumpSingleJson: true,
+      noWarnings: true,
     });
 }
 
@@ -292,7 +293,7 @@ export class YouTubeMusic {
    * @returns {YouTubeSearchResult} YouTubeMusicSearchResults
    */
   async search(artists, track, album, duration) {
-    [artists, track, duration] = _getSearchArgs(artists, track, album, duration);
+    [artists, track, album, duration] = _getSearchArgs(artists, track, album, duration);
 
     const results = await this.#search({query: [track, album, ...artists].join(' ')});
     const strippedMeta = textUtils.stripText([...track.split(' '), album, ...artists]);


### PR DESCRIPTION
Related upstream issue: https://github.com/microlinkhq/youtube-dl-exec/issues/153

Our dependency youtube-dl-exec treats non-empty stderr content as hard errors. And since yt-dlp also writes warnings to stderr, youtube-dl-exec fails to handle those cases where a warning isn't an error.

This patch makes it so yt-dlp doesn't emit any warnings.