### PR TITLE
chore: fix source feed extraction

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -1415,11 +1415,13 @@ async function init(packageJson, queries, options) {
           },
         })
         .then(trackObject => ({...trackObject, meta}))
-        .catch(errObject => ({
-          meta,
-          [symbols.errorCode]: 10,
-          ...errObject,
-        }));
+        .catch(errObject => {
+          return {
+            meta,
+            [symbols.errorCode]: 10,
+            ...(symbols.errorCode in errObject ? errObject : {err: errObject}),
+          };
+        });
     },
   );
 

--- a/cli.js
+++ b/cli.js
@@ -1334,9 +1334,7 @@ async function init(packageJson, queries, options) {
     });
     if (!audioFeeds || audioFeeds.err) return {meta, err: (audioFeeds || {}).err, [symbols.errorCode]: 2};
 
-    const [feedMeta] = audioFeeds.formats
-      .filter(meta => 'abr' in meta && !('vbr' in meta))
-      .sort((meta1, meta2) => meta2.abr - meta1.abr);
+    const [feedMeta] = audioFeeds.formats.filter(meta => meta.abr && !meta.vbr).sort((meta1, meta2) => meta2.abr - meta1.abr);
 
     meta.fingerprint = crypto.createHash('md5').update(`${audioSource.source.videoId} ${feedMeta.format_id}`).digest('hex');
     const files = await downloadQueue.push({track, meta, feedMeta, trackLogger}).catch(errObject =>


### PR DESCRIPTION
Looks like `yt-dlp` might've changed the output format expected by freyr. In previous versions, `abr` and `vbr` in the json data used to be `null` when not specified. Now, it's `0` when not specified.

This updates the logic to adapt to that.