### PR TITLE
chore: cleanup migration logic

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -631,16 +631,8 @@ async function init(packageJson, queries, options) {
     },
     migrations: {
       '0.9.1': store => {
-        let spotify = store.get('services.spotify');
-        if (spotify.refresh_token) {
-          spotify.refreshToken = spotify.refresh_token;
-          delete spotify.refresh_token;
-        }
-        if (spotify.access_token) {
-          spotify.accessToken = spotify.access_token;
-          delete spotify.access_token;
-        }
-        store.set('services.spotify', spotify);
+        // dump any old config for Spotify before this point
+        store.set('services.spotify', {});
         stackLogger.write('[done]\n');
       },
     },

--- a/cli.js
+++ b/cli.js
@@ -626,7 +626,7 @@ async function init(packageJson, queries, options) {
     schema,
     serialize: v => JSON.stringify(v, null, 2),
     beforeEachMigration: (_, context) => {
-      if (context.fromVersion === '0.0.0') stackLogger.print(`[•] Migrating config file to v${context.toVersion}...`);
+      if (context.fromVersion === '0.0.0') stackLogger.print(`[•] Initializing config file...`);
       else stackLogger.print(`[•] Migrating config file from v${context.fromVersion} → v${context.toVersion}...`);
     },
     migrations: {


### PR DESCRIPTION
Fresh runs of freyr shouldn't be getting the message "Migrating config file to v0.9.1"

This also dumps all spotify related config pre-v0.9.1 since https://github.com/miraclx/freyr-js/pull/454 introduced new credentials. There's no point in retaining old tokens.