### PR TITLE
fix: cwd should not be implicitly checked when the download dir is elsewhere

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -1376,7 +1376,7 @@ async function init(packageJson, queries, options) {
       const outFilePath = xpath.join(BASE_DIRECTORY, trackPath, outFileName);
       const fileExistsIn = (
         await Promise.all(
-          CHECK_DIRECTORIES.map(dir => xpath.join(dir, trackPath, outFileName)).map(async path => [
+          [outFilePath, ...CHECK_DIRECTORIES.map(dir => xpath.join(dir, trackPath, outFileName))].map(async path => [
             path,
             !!(await maybeStat(xpath.join(path))),
           ]),

--- a/cli.js
+++ b/cli.js
@@ -631,8 +631,13 @@ async function init(packageJson, queries, options) {
     },
     migrations: {
       '0.9.1': store => {
-        // dump any old config for Spotify before this point
+        // https://github.com/miraclx/freyr-js/pull/454
+        // Dump any old config for Spotify before this point
         store.set('services.spotify', {});
+        // https://github.com/miraclx/freyr-js/pull/527
+        // Check dirs shouldn't default to current directory, but rather the output directory
+        if ((c => Array.isArray(c) && c.length === 1 && c[0] === '.')(store.get('config.dirs.check')))
+          store.set('config.dirs.check', []);
         stackLogger.write('[done]\n');
       },
     },

--- a/conf.json
+++ b/conf.json
@@ -20,9 +20,7 @@
   "filters": [],
   "dirs": {
     "output": ".",
-    "check": [
-      "."
-    ],
+    "check": [],
     "cache": {
       "path": "<cache>",
       "keep": true


### PR DESCRIPTION
`freyr <src> -d ..` will check the current working directory for the presence of the track which isn't the behaviour we intend to have.

This patch fixes that.
