### PR TITLE
fix: urify logic for Apple Music and Deezer

### DIFF
--- a/README.md
+++ b/README.md
@@ -917,119 +917,113 @@ To preview filter rules specification, use the `filter` subcommand.
       <tr>
         <td rowspan=8> Spotify </td>
         <td rowspan=2> track </td>
-          <td> URL </td>
-          <td> <a href="https://open.spotify.com/track/127QTOFJsJQp5LbJbu3A1y"> https://open.spotify.com/track/127QTOFJsJQp5LbJbu3A1y </a> </td>
-        </tr>
-        <tr>
-          <td> URI </td>
-          <td> <code> spotify:track:127QTOFJsJQp5LbJbu3A1y </code> </td>
-        </tr>
-        <tr>
-          <td rowspan=2> album </td>
-          <td> URL </td>
-          <td> <a href="https://open.spotify.com/album/623PL2MBg50Br5dLXC9E9e"> https://open.spotify.com/album/623PL2MBg50Br5dLXC9E9e </a> </td>
-        </tr>
-          <tr>
-            <td> URI </td>
-            <td> <code> spotify:album:623PL2MBg50Br5dLXC9E9e </code> </td>
-          </tr>
-        <tr>
-          <td rowspan=2> artist </td>
-          <td> URL </td>
-          <td> <a href="https://open.spotify.com/artist/6M2wZ9GZgrQXHCFfjv46we"> https://open.spotify.com/artist/6M2wZ9GZgrQXHCFfjv46we </a> </td>
-        </tr>
-          <tr>
-            <td> URI </td>
-            <td> <code> spotify:artist:6M2wZ9GZgrQXHCFfjv46we </code> </td>
-          </tr>
-        <tr>
-          <td rowspan=2> playlist </td>
-          <td> URL </td>
-          <td> <a href="https://open.spotify.com/playlist/37i9dQZF1DXcBWIGoYBM5M"> https://open.spotify.com/playlist/37i9dQZF1DXcBWIGoYBM5M </a> </td>
-        </tr>
-          <tr>
-            <td> URI </td>
-            <td> <code> spotify:playlist:37i9dQZF1DXcBWIGoYBM5M </code> </td>
-          </tr>
-        </tr>
+        <td> URL </td>
+        <td> <a href="https://open.spotify.com/track/127QTOFJsJQp5LbJbu3A1y"> https://open.spotify.com/track/127QTOFJsJQp5LbJbu3A1y </a> </td>
+      </tr>
+      <tr>
+        <td> URI </td>
+        <td> <code> spotify:track:127QTOFJsJQp5LbJbu3A1y </code> </td>
+      </tr>
+      <tr>
+        <td rowspan=2> album </td>
+        <td> URL </td>
+        <td> <a href="https://open.spotify.com/album/623PL2MBg50Br5dLXC9E9e"> https://open.spotify.com/album/623PL2MBg50Br5dLXC9E9e </a> </td>
+      </tr>
+      <tr>
+        <td> URI </td>
+        <td> <code> spotify:album:623PL2MBg50Br5dLXC9E9e </code> </td>
+      </tr>
+      <tr>
+        <td rowspan=2> artist </td>
+        <td> URL </td>
+        <td> <a href="https://open.spotify.com/artist/6M2wZ9GZgrQXHCFfjv46we"> https://open.spotify.com/artist/6M2wZ9GZgrQXHCFfjv46we </a> </td>
+      </tr>
+      <tr>
+        <td> URI </td>
+        <td> <code> spotify:artist:6M2wZ9GZgrQXHCFfjv46we </code> </td>
+      </tr>
+      <tr>
+        <td rowspan=2> playlist </td>
+        <td> URL </td>
+        <td> <a href="https://open.spotify.com/playlist/37i9dQZF1DXcBWIGoYBM5M"> https://open.spotify.com/playlist/37i9dQZF1DXcBWIGoYBM5M </a> </td>
+      </tr>
+      <tr>
+        <td> URI </td>
+        <td> <code> spotify:playlist:37i9dQZF1DXcBWIGoYBM5M </code> </td>
       </tr>
       <tr>
         <td rowspan=8> Apple Music </td>
         <td rowspan=2> track </td>
-          <td> URL </td>
-          <td> <a href="https://music.apple.com/us/album/say-so-feat-nicki-minaj/1510821672?i=1510821685"> https://music.apple.com/us/album/say-so-feat-nicki-minaj/1510821672?i=1510821685 </a> </td>
-        </tr>
-        <tr>
-          <td> URI </td>
-          <td> <code> apple_music:track:1510821685 </code> </td>
-        </tr>
-        <tr>
-          <td rowspan=2> album </td>
-          <td> URL </td>
-          <td> <a href="https://music.apple.com/us/album/birds-of-prey-the-album/1493581254"> https://music.apple.com/us/album/birds-of-prey-the-album/1493581254 </a> </td>
-        </tr>
-          <tr>
-            <td> URI </td>
-            <td> <code> apple_music:album:1493581254 </code> </td>
-          </tr>
-        <tr>
-          <td rowspan=2> artist </td>
-          <td> URL </td>
-          <td> <a href="https://music.apple.com/us/artist/412778295"> https://music.apple.com/us/artist/412778295 </a> </td>
-        </tr>
-          <tr>
-            <td> URI </td>
-            <td> <code> apple_music:artist:412778295 </code> </td>
-          </tr>
-        <tr>
-          <td rowspan=2> playlist </td>
-          <td> URL </td>
-          <td> <a href="https://music.apple.com/us/playlist/todays-hits/pl.f4d106fed2bd41149aaacabb233eb5eb"> https://music.apple.com/us/playlist/todays-hits/pl.f4d106fed2bd41149aaacabb233eb5eb </a> </td>
-        </tr>
-          <tr>
-            <td> URI </td>
-            <td> <code> apple_music:playlist:pl.f4d106fed2bd41149aaacabb233eb5eb </code> </td>
-          </tr>
-        </tr>
+        <td> URL </td>
+        <td> <a href="https://music.apple.com/us/album/say-so-feat-nicki-minaj/1510821672?i=1510821685"> https://music.apple.com/us/album/say-so-feat-nicki-minaj/1510821672?i=1510821685 </a> </td>
+      </tr>
+      <tr>
+        <td> URI </td>
+        <td> <code> apple_music:track:1510821672i1510821685 </code> </td>
+      </tr>
+      <tr>
+        <td rowspan=2> album </td>
+        <td> URL </td>
+        <td> <a href="https://music.apple.com/us/album/birds-of-prey-the-album/1493581254"> https://music.apple.com/us/album/birds-of-prey-the-album/1493581254 </a> </td>
+      </tr>
+      <tr>
+        <td> URI </td>
+        <td> <code> apple_music:album:1493581254 </code> </td>
+      </tr>
+      <tr>
+        <td rowspan=2> artist </td>
+        <td> URL </td>
+        <td> <a href="https://music.apple.com/us/artist/412778295"> https://music.apple.com/us/artist/412778295 </a> </td>
+      </tr>
+      <tr>
+        <td> URI </td>
+        <td> <code> apple_music:artist:412778295 </code> </td>
+      </tr>
+      <tr>
+        <td rowspan=2> playlist </td>
+        <td> URL </td>
+        <td> <a href="https://music.apple.com/us/playlist/todays-hits/pl.f4d106fed2bd41149aaacabb233eb5eb"> https://music.apple.com/us/playlist/todays-hits/pl.f4d106fed2bd41149aaacabb233eb5eb </a> </td>
+      </tr>
+      <tr>
+        <td> URI </td>
+        <td> <code> apple_music:playlist:pl.f4d106fed2bd41149aaacabb233eb5eb </code> </td>
       </tr>
       <tr>
         <td rowspan=8> Deezer </td>
         <td rowspan=2> track </td>
-          <td> URL </td>
-          <td> <a href="https://www.deezer.com/en/track/642674232"> https://www.deezer.com/en/track/642674232 </a> </td>
-        </tr>
-        <tr>
-          <td> URI </td>
-          <td> <code> deezer:track:642674232 </code> </td>
-        </tr>
-        <tr>
-          <td rowspan=2> album </td>
-          <td> URL </td>
-          <td> <a href="https://www.deezer.com/en/album/99687992"> https://www.deezer.com/en/album/99687992 </a> </td>
-        </tr>
-          <tr>
-            <td> URI </td>
-            <td> <code> deezer:album:99687992 </code> </td>
-          </tr>
-        <tr>
-          <td rowspan=2> artist </td>
-          <td> URL </td>
-          <td> <a href="https://www.deezer.com/en/artist/5340439"> https://www.deezer.com/en/artist/5340439 </a> </td>
-        </tr>
-          <tr>
-            <td> URI </td>
-            <td> <code> deezer:artist:5340439 </code> </td>
-          </tr>
-        <tr>
-          <td rowspan=2> playlist </td>
-          <td> URL </td>
-          <td> <a href="https://www.deezer.com/en/playlist/1963962142"> https://www.deezer.com/en/playlist/1963962142 </a> </td>
-        </tr>
-          <tr>
-            <td> URI </td>
-            <td> <code> deezer:playlist:1963962142 </code> </td>
-          </tr>
-        </tr>
+        <td> URL </td>
+        <td> <a href="https://www.deezer.com/en/track/642674232"> https://www.deezer.com/en/track/642674232 </a> </td>
+      </tr>
+      <tr>
+        <td> URI </td>
+        <td> <code> deezer:track:642674232 </code> </td>
+      </tr>
+      <tr>
+        <td rowspan=2> album </td>
+        <td> URL </td>
+        <td> <a href="https://www.deezer.com/en/album/99687992"> https://www.deezer.com/en/album/99687992 </a> </td>
+      </tr>
+      <tr>
+        <td> URI </td>
+        <td> <code> deezer:album:99687992 </code> </td>
+      </tr>
+      <tr>
+        <td rowspan=2> artist </td>
+        <td> URL </td>
+        <td> <a href="https://www.deezer.com/en/artist/5340439"> https://www.deezer.com/en/artist/5340439 </a> </td>
+      </tr>
+      <tr>
+        <td> URI </td>
+        <td> <code> deezer:artist:5340439 </code> </td>
+      </tr>
+      <tr>
+        <td rowspan=2> playlist </td>
+        <td> URL </td>
+        <td> <a href="https://www.deezer.com/en/playlist/1963962142"> https://www.deezer.com/en/playlist/1963962142 </a> </td>
+      </tr>
+      <tr>
+        <td> URI </td>
+        <td> <code> deezer:playlist:1963962142 </code> </td>
       </tr>
     </tbody>
   </table>
@@ -1126,7 +1120,7 @@ For more information and documentation about docker, please refer to its officia
 
 ## License
 
-[Apache 2.0][license] © **Miraculous Owonubi** ([@miraclx][author-url]) \<omiraculous@gmail.com\>
+[Apache 2.0][license] © **Miraculous Owonubi** ([@miraclx][author-url]) \<<omiraculous@gmail.com>\>
 
 [license]:  LICENSE "Apache 2.0 License"
 [author-url]: https://github.com/miraclx

--- a/cli.js
+++ b/cli.js
@@ -2169,7 +2169,7 @@ function prepCli(packageJson) {
       console.log('  spotify:album:2D23kwwoy2JpZVuJwzE42B');
       console.log('');
       console.log('  $ freyr urify -t https://music.apple.com/us/album/say-so-feat-nicki-minaj/1510821672?i=1510821685');
-      console.log('  apple_music:track:1510821685');
+      console.log('  apple_music:track:1510821672i1510821685');
       console.log('');
       console.log(
         [

--- a/cli.js
+++ b/cli.js
@@ -2157,7 +2157,7 @@ function prepCli(packageJson) {
           }
         })
         .then(() => {
-          console.error('\x1b[32m[+]\x1b[0m Urify complete');
+          console.error('\x1b[32m[+]\x1b[0m Urify Complete');
           if (args.output) console.error(`Successfully written to [${args.output}]`);
           if (output !== process.stdout) output.end();
         });

--- a/src/services/apple_music.js
+++ b/src/services/apple_music.js
@@ -42,7 +42,7 @@ export default class AppleMusic {
     this.#store.core = new Client({developerToken: config.developerToken});
     for (let instance of [this.#store.core.albums, this.#store.core.artists, this.#store.core.playlists, this.#store.core.songs])
       instance.axiosInstance.interceptors.request.use(conf => ((conf.headers.origin = 'https://music.apple.com'), conf));
-    this.#store.defaultStorefront = config.storefront || 'us';
+    this.#store.defaultStorefront = config.storefront;
     this.#store.isAuthenticated = !!config.developerToken;
   }
 
@@ -100,7 +100,7 @@ export default class AppleMusic {
       refID,
       key: match[3] || null,
       uri: `apple_music:${type}:${id || refID}`,
-      storefront: match[1] || storefront || this.#store.defaultStorefront,
+      storefront: match[1] || storefront || this.#store.defaultStorefront || 'us',
       collection_type,
     };
   }

--- a/src/services/deezer.js
+++ b/src/services/deezer.js
@@ -186,7 +186,7 @@ export default class Deezer {
     const parsedURL = url.parse(uri, true);
     const id = isURI ? match[4] : path.basename(parsedURL.pathname);
     const type = match[isURI ? 3 : 1];
-    return {id, type, uri: `deezer:${type}:${id}`};
+    return {id, type, uri: `deezer:${type}:${id}`, url: `https://www.deezer.com/${type}/${id}`};
   }
 
   wrapTrackMeta(trackInfo, albumInfo = {}) {


### PR DESCRIPTION
Before this patch, the `urify` command didn't work as expected with Apple Music and Deezer.

Outright broken with Apple Music parsing, with the error:

```console
TypeError: Cannot read private member #store from an object whose class did not declare it
    at Object.parseURI (file:///freyr-js/src/services/apple_music.js:103:50)
    at FreyrCore.parseURI (file:///freyr-js/src/freyr.js:43:39)
```

And failing to return URLs when requested (`--url`) for Deezer.

Working on this patch, I also realized Apple Music URLs need to be qualified with the album IDs.

So, with a URL of https://music.apple.com/us/album/say-so-feat-nicki-minaj/1510821672?i=1510821685

The previous URIfication would result in `apple_music:track:1510821685`

And attempting to reconstruct a URL from that would be missing the album ID - `1510821672`

This patch extends the format of the Apple Music URIfied format. Specifically for tracks.

So instead of `apple_music:track:1510821685`, it now comes prepended with the album ID. Delineated with an `i`

Becoming `apple_music:track:1510821672i1510821685`

And finally, I noticed the Apple Music parsing logic did not account for periods `.` in the ID position. And playlists have exactly that. This has been patched as well.