### PR TITLE
fix: collection order

### DIFF
--- a/src/services/spotify.js
+++ b/src/services/spotify.js
@@ -229,6 +229,10 @@ export default class Spotify {
       return [parsedURI.id, this.#store.cache.get(uri)];
     });
     const ids = uris.filter(([, value]) => !value).map(([id]) => id);
+    let results = new Map();
+    for (const [id, result] of uris) {
+      results.set(id, result);
+    }
     uris = Object.fromEntries(uris);
     if (ids.length)
       (
@@ -241,10 +245,9 @@ export default class Spotify {
         )
       )
         .flat(1)
-        .forEach(item => (!item ? null : (this.#store.cache.set(item.uri, item), (uris[item.id] = item))));
-
-    const ret = Object.values(uris);
-    return !wasArr ? ret[0] : ret;
+        .forEach(item => (!item ? null : (this.#store.cache.set(item.uri, item), results.set(item.id, item))));
+    results = [...results.values()];
+    return !wasArr ? results[0] : results;
   }
 
   async getTrack(uris, country) {


### PR DESCRIPTION
JS objects have no guarantees of maintaining insertion order. The use of `fromEntries` to construct an object of numeric keys orders them numerically. Which is not what we want.

Fixes #568.

This is observable in the case of Apple Music, but even though we use the same logic for Spotify, their IDs are alphanumeric, so insertion order appears to be preserved. But we rewrite that section of code as well for correctness.