### PR TITLE
fix: support multi-lang source feed lookup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,6 @@
         "spotify-uri": "^4.0.0",
         "stringd": "^2.2.0",
         "stringd-colors": "^1.10.0",
-        "stripchar": "^1.2.1",
         "xbytes": "^1.8.0",
         "xprogress": "^0.20.0",
         "youtube-dl-exec": "^2.4.0",
@@ -4133,11 +4132,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/stripchar": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/stripchar/-/stripchar-1.2.1.tgz",
-      "integrity": "sha1-bpPDT14C/RGwo/UuQnqWrwbzmUc="
-    },
     "node_modules/strtok3": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-7.0.0.tgz",
@@ -4836,7 +4830,7 @@
       "resolved": "https://registry.npmjs.org/@yujinakayama/apple-music/-/apple-music-0.4.1.tgz",
       "integrity": "sha512-PnjTz5nXrUo6N/UJdwPPw9fscY5qlGpJxl0jLTldEs8hBKlV+3eSNnzullRCsMON7zy/01vxJBSbN5to8zM1gQ==",
       "requires": {
-        "axios": "1.4.0"
+        "axios": "1.5.0"
       },
       "dependencies": {
         "axios": {
@@ -7511,11 +7505,6 @@
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
       "dev": true
-    },
-    "stripchar": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/stripchar/-/stripchar-1.2.1.tgz",
-      "integrity": "sha1-bpPDT14C/RGwo/UuQnqWrwbzmUc="
     },
     "strtok3": {
       "version": "7.0.0",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,6 @@
     "spotify-uri": "^4.0.0",
     "stringd": "^2.2.0",
     "stringd-colors": "^1.10.0",
-    "stripchar": "^1.2.1",
     "xbytes": "^1.8.0",
     "xprogress": "^0.20.0",
     "youtube-dl-exec": "^2.4.0",

--- a/src/text_utils.js
+++ b/src/text_utils.js
@@ -23,10 +23,7 @@ function stripText(data) {
     ...new Set(
       data.reduce(
         (all, text) =>
-          (text = text
-            .normalize('NFD')
-            .replace(/\p{Diacritic}/gu, '')
-            .replace(/[^\p{Letter} \p{Number}]/gu, ''))
+          (text = text.normalize('NFD').replace(/\p{Diacritic}|[^\p{Letter} \p{Number}]/gu, ''))
             ? all.concat([text.replace(/\s{2,}/g, ' ').toLowerCase()])
             : all,
         [],

--- a/src/text_utils.js
+++ b/src/text_utils.js
@@ -1,5 +1,3 @@
-import {StripChar} from 'stripchar';
-
 /**
  * Stripout invalid characters, symbols and unnecessary spaces
  *
@@ -25,7 +23,10 @@ function stripText(data) {
     ...new Set(
       data.reduce(
         (all, text) =>
-          (text = StripChar.RSspecChar(text.normalize('NFD').replace(/\p{Diacritic}/gu, '')))
+          (text = text
+            .normalize('NFD')
+            .replace(/\p{Diacritic}/gu, '')
+            .replace(/[^\p{Letter} \p{Number}]/gu, ''))
             ? all.concat([text.replace(/\s{2,}/g, ' ').toLowerCase()])
             : all,
         [],

--- a/yarn.lock
+++ b/yarn.lock
@@ -1957,7 +1957,7 @@ node-fzf@0.11.0, node-fzf@~0.5.1:
   resolved "https://registry.npmjs.org/node-fzf/-/node-fzf-0.11.0.tgz"
   integrity sha512-djlXFlrGSrGCHVHOr4iPRkfPuZXac6Elv0wBtKEJ383Dd/rj+9zaCu4JDZQVSGvoDRRSfJYL4roK9SLjTxeOIg==
   dependencies:
-    cli-color "~2.0.0"
+    cli-color "~1.2.0"
     keypress "~0.2.1"
     minimist "~1.2.5"
     redstar "0.0.2"
@@ -2563,11 +2563,6 @@ strip-json-comments@^3.1.1:
   version "3.1.1"
   resolved "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz"
   integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
-
-stripchar@^1.2.1:
-  version "1.2.1"
-  resolved "https://registry.npmjs.org/stripchar/-/stripchar-1.2.1.tgz"
-  integrity sha1-bpPDT14C/RGwo/UuQnqWrwbzmUc=
 
 strtok3@^7.0.0:
   version "7.0.0"


### PR DESCRIPTION
We previously used the library `stripchar` to remove symbols from the query sent off to YouTube( Music).

The logic in there was using the regex `[^a-zA-Z 0-9]` which removed all non-alphanumerics including non-Latin letters.

This isn't the behaviour we want. We want non-Latin letters to work as well.

So this patch defers to unicode categorizations and hand writes the replacement logic.