### PR TITLE
fix(Apple Music): fix incorrect Apple Music uri report

### DIFF
--- a/src/services/apple_music.js
+++ b/src/services/apple_music.js
@@ -109,7 +109,7 @@ export default class AppleMusic {
   wrapTrackMeta(trackInfo, albumInfo = {}) {
     return {
       id: trackInfo.id,
-      uri: `apple_music:track:${albumInfo.id}i${trackInfo.id}`,
+      uri: `apple_music:track:${trackInfo.id}`,
       link: trackInfo.attributes.url,
       name: trackInfo.attributes.name,
       artists: [trackInfo.attributes.artistName],


### PR DESCRIPTION
Following the reversal of the Apple Music track URI update from https://github.com/miraclx/freyr-js/pull/549 in https://github.com/miraclx/freyr-js/pull/552.

The update of the urified format was not reverted.

This patch fixes that.