### PR TITLE
fix(meta): use correct total disc number count

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,22 +50,22 @@ Depending on the URLs you provide freyr, it will;
 
 Here's a list of the metadata that freyr can extract from each streaming service:
 
-|      Meta      | Spotify | Apple Music | Deezer |
-| :------------: | :-----: | :---------: | :----: |
-|    `Title`     |    ✔    |      ✔      |   ✔    |
-|    `Artist`    |    ✔    |      ✔      |   ✔    |
-|   `Composer`   |    ✗    |      ✔      |   ✔    |
-|    `Album`     |    ✔    |      ✔      |   ✔    |
-|    `Genre`     |    ✗    |      ✔      |   ✔    |
-| `Track Number` |    ✔    |      ✔      |   ✔    |
-| `Disk Number`  |    ✔    |      ✔      |   ✔    |
-| `Release Date` |    ✔    |      ✔      |   ✔    |
-|    `Rating`    |    ✔    |      ✔      |   ✔    |
-| `Album Artist` |    ✔    |      ✔      |   ✔    |
-|     `ISRC`     |    ✔    |      ✔      |   ✔    |
-|    `Label`     |    ✔    |      ✔      |   ✔    |
-|  `Copyright`   |    ✔    |      ✔      |   ✗    |
-|  `Cover Art`   |    ✔    |      ✔      |   ✔    |
+|      Meta      | Spotify | Apple Music |      Deezer       |
+| :------------: | :-----: | :---------: | :---------------: |
+|    `Title`     |    ✔    |      ✔      |        ✔          |
+|    `Artist`    |    ✔    |      ✔      |        ✔          |
+|   `Composer`   |    ✗    |      ✔      |        ✔          |
+|    `Album`     |    ✔    |      ✔      |        ✔          |
+|    `Genre`     |    ✗    |      ✔      |        ✔          |
+| `Track Number` |    ✔    |      ✔      |        ✔          |
+| `Disk Number`  |    ✔    |      ✔      |   ✔ (no total)    |
+| `Release Date` |    ✔    |      ✔      |        ✔          |
+|    `Rating`    |    ✔    |      ✔      |        ✔          |
+| `Album Artist` |    ✔    |      ✔      |        ✔          |
+|     `ISRC`     |    ✔    |      ✔      |        ✔          |
+|    `Label`     |    ✔    |      ✔      |        ✔          |
+|  `Copyright`   |    ✔    |      ✔      |        ✗          |
+|  `Cover Art`   |    ✔    |      ✔      |        ✔          |
 
 ## Support the project
 

--- a/cli.js
+++ b/cli.js
@@ -1108,7 +1108,7 @@ async function init(packageJson, queries, options) {
           album: track.album, // ©alb
           genre: (genre => (genre ? genre.concat(' ') : ''))((track.genres || [])[0]), // ©gen | gnre
           tracknum: `${track.track_number}/${track.total_tracks}`, // trkn
-          disk: `${track.disc_number}/${track.disc_number}`, // disk
+          disk: `${track.disc_number}${track.total_discs ? `/${track.total_discs}` : ''}`, // disk
           year: new Date(track.release_date).toISOString().split('T')[0], // ©day
           compilation: track.compilation, // ©cpil
           gapless: options.gapless, // pgap

--- a/src/services/apple_music.js
+++ b/src/services/apple_music.js
@@ -167,6 +167,7 @@ export default class AppleMusic {
       total_tracks: albumInfo.ntracks,
       release_date: albumInfo.release_date,
       disc_number: trackInfo.attributes.discNumber,
+      total_discs: albumInfo.tracks.reduce((acc, track) => Math.max(acc, track.attributes.discNumber), 1),
       contentRating: trackInfo.attributes.contentRating,
       isrc: trackInfo.attributes.isrc,
       genres: trackInfo.attributes.genreNames,

--- a/src/services/spotify.js
+++ b/src/services/spotify.js
@@ -153,6 +153,7 @@ export default class Spotify {
           total_tracks: albumInfo.ntracks,
           release_date: albumInfo.release_date,
           disc_number: trackInfo.disc_number,
+          total_discs: albumInfo.tracks.reduce((acc, track) => Math.max(acc, track.disc_number), 1),
           contentRating: trackInfo.explicit === true ? 'explicit' : 'clean',
           isrc: (trackInfo.external_ids || {}).isrc,
           genres: albumInfo.genres,


### PR DESCRIPTION
Deezer's API unfortunately, doesn't include any way to derive the total disc count of an album.

There's an alt-API we could use for this (which also provides us copyright information)

```console
$ xh 'https://www.deezer.com/ajax/gw-light.php?method=deezer.getUserData&api_version=1.0&api_token=' \
  | jq '{cf: .results.checkForm, sid: .results.SESSION_ID}'
{
  "cf": "8MBdPkLVd3V~Exj0gJP0chXXXgM~2yb0",
  "sid": "fr0f7920da51b1f2b72dbbc7052a4a4141872d94"
}

$ xh 'https://www.deezer.com/ajax/gw-light.php?method=deezer.pageAlbum&api_version=1.0&api_token=8MBdPkLVd3V~Exj0gJP0chXXXgM~2yb0' \
    cookie:sid=fr0f7920da51b1f2b72dbbc7052a4a4141872d94 \
    alb_id:=264169542 lang=us \
  | jq -r '{total_discs: [.results.SONGS.data[] | .DISK_NUMBER] | unique | sort | reverse[0], copyright: .results.DATA.PRODUCER_LINE}'
{
  "total_discs": "3",
  "copyright": "(P) 2021 Floating World LTD"
}
```