### PR TITLE
feat: standardize copyright format

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -1138,7 +1138,10 @@ async function init(packageJson, queries, options) {
           // ownr? <owner>
           purchaseDate: 'timestamp', // purd
           apID: 'cli@freyr.git', // apID
-          copyright: track.copyrights.sort(({type}) => (type === 'P' ? -1 : 1))[0]?.text, // cprt
+          copyright: track.copyrights
+            .sort(({type}) => (type === 'P' ? -1 : 1))[0]
+            ?.text?.replace('(P)', '℗')
+            ?.replace('(C)', '©'), // cprt
           encodingTool: `freyr-js cli v${packageJson.version}`, // ©too
           encodedBy: 'd3vc0dr', // ©enc
           artwork: files.image.file.path, // covr


### PR DESCRIPTION
Apple Music would use `℗ {YEAR} {LABEL}` where Spotify would use `(P) {YEAR} {LABEL}`

This standardizes it to prefer Apple Music's