### PR TITLE
chore: assert the presence of the yt-dlp dep

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,8 @@ FROM node:20.2.0-alpine3.16 as installer
 COPY package.json yarn.lock /freyr/
 WORKDIR /freyr
 ARG YOUTUBE_DL_SKIP_PYTHON_CHECK=1
-RUN yarn install --prod --frozen-lockfile
+RUN yarn install --prod --frozen-lockfile \
+  && test -x node_modules/youtube-dl-exec/bin/yt-dlp
 
 FROM golang:1.20.4-alpine3.16 as prep
 


### PR DESCRIPTION
Add a test to ensure the `yt-dlp` binary is present after `install` has been run.

> Found out why CI was failing, over-dependence on caches. Looks like 2 months ago, we cached an image that didn't appropriately download the `yt-dlp` subdependency of `youtube-dl-exec` and we kept reusing that image since freyr didn't change in this period of time.
> 
> Had to evict caches, and now it works! - [miraclx/freyr-js/actions/runs/8623905754/job/23690297872](https://github.com/miraclx/freyr-js/actions/runs/8623905754/job/23690297872)

_Originally posted by @miraclx in https://github.com/miraclx/freyr-js/issues/669#issuecomment-2048877760_

Linked: https://github.com/microlinkhq/youtube-dl-exec/issues/190