### PR TITLE
Fix downloading from Apple Music: update core script regex to new format

### DIFF
--- a/src/services/apple_music.js
+++ b/src/services/apple_music.js
@@ -108,7 +108,7 @@ export default class AppleMusic {
   async login() {
     let browsePage = await got('https://music.apple.com/us/browse').text();
     let scriptUri;
-    if (!(scriptUri = browsePage.match(/assets\/index-[a-z0-9]{8}\.js/)?.[0]))
+    if (!(scriptUri = browsePage.match(/assets\/index~[a-z0-9]{10}\.js/)?.[0]))
       throw new Error('Unable to extract core script from Apple Music');
     let script = await got(`https://music.apple.com/${scriptUri}`).text();
     let developerToken;


### PR DESCRIPTION
This fixes #752, where downloading from Apple Music would always fail with a "Unable to extract core script from Apple Music" error.

The cause is a change in the script name format: the separator goes from `-` to `~`, and the hash is now two characters longer.
